### PR TITLE
Down migration used the wrong table name

### DIFF
--- a/database/migrations/2016_01_01_000000_create_uptime_monitors_table.php
+++ b/database/migrations/2016_01_01_000000_create_uptime_monitors_table.php
@@ -39,6 +39,6 @@ class CreateSitesTable extends Migration
      */
     public function down()
     {
-        Schema::drop('ping_monitors');
+        Schema::drop('sites');
     }
 }


### PR DESCRIPTION
The create side of the migration creates a table called `sites` but dropped a table called `ping_monitors`.