### PR TITLE
Typo in Changelog.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 All Notable changes to `laravel-uptime-monitor` will be documented in this file
 
-## 1.0.2 - 2017-11-24
+## 1.0.2 - 2016-11-24
 
 - fix descriptions in config file
 
-## 1.0.1 - 2017-11-21
+## 1.0.1 - 2016-11-21
 
 - fix custom model instructions in config file
 
-## 1.0.0 - 2017-11-21
+## 1.0.0 - 2016-11-21
 
 - initial release


### PR DESCRIPTION
We have actual 2016, not 2017 or did you release the package in the future :)?