### PR TITLE
[WIP] Implement other monitor protocols

### DIFF
--- a/config/laravel-uptime-monitor.php
+++ b/config/laravel-uptime-monitor.php
@@ -82,6 +82,11 @@ return [
          * given number of seconds.
          */
         'timeout_per_site' => 10,
+        /*
+         * The uptime check for a monitor will fail if server does not respond after the
+         * given number of seconds.
+         */
+        'timeout_per_connection' => 2,
 
         /*
          * Fire `Spatie\UptimeMonitor\Events\MonitorFailed` event only after

--- a/src/Checker/Checker.php
+++ b/src/Checker/Checker.php
@@ -1,14 +1,5 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: lukaskammerling
- * Date: 28.11.16
- * Time: 10:30
- */
-
 namespace Spatie\UptimeMonitor\Checker;
-
-
 
 
 use Spatie\UptimeMonitor\MonitorCollection;

--- a/src/Checker/Checker.php
+++ b/src/Checker/Checker.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: lukaskammerling
+ * Date: 28.11.16
+ * Time: 10:30
+ */
+
+namespace Spatie\UptimeMonitor\Checker;
+
+
+
+
+use Spatie\UptimeMonitor\MonitorCollection;
+
+/**
+ * Class Checker
+ * @package Spatie\UptimeMonitor\Checker
+ */
+abstract class Checker
+{
+    /**
+     * @var MonitorCollection
+     */
+    protected $monitors;
+
+    /**
+     * @param MonitorCollection $monitors
+     * @return mixed
+     */
+    abstract public function check(MonitorCollection $monitors);
+}

--- a/src/Checker/CheckerRepository.php
+++ b/src/Checker/CheckerRepository.php
@@ -1,0 +1,67 @@
+<?php
+namespace Spatie\UptimeMonitor\Checker;
+
+use Illuminate\Support\Collection;
+use Spatie\UptimeMonitor\Exceptions\InvalidArgument;
+
+/**
+ * Created by PhpStorm.
+ * User: lukaskammerling
+ * Date: 28.11.16
+ * Time: 10:28
+ */
+class CheckerRepository
+{
+    /**
+     * @var Collection
+     */
+    protected $protocolsToChecker = [];
+
+
+    /**
+     * @var
+     */
+    protected static $self;
+
+    /**
+     * @param $protocol
+     * @param Checker $checker
+     */
+    public function addChecker($protocol, Checker $checker)
+    {
+        if (!array_key_exists($protocol, $this->protocolsToChecker)) {
+            $this->protocolsToChecker[$protocol] = null;
+        }
+        if (!empty($this->protocolsToChecker[$protocol])) {
+            throw InvalidArgument::checkerAlreadyRegisterd($protocol);
+        }
+        $this->protocolsToChecker[$protocol] = $checker;
+    }
+
+    /**
+     * @param null $protocol
+     * @return array
+     */
+    public function getChecker($protocol = null): array
+    {
+        if ($protocol != null) {
+            if (array_key_exists($protocol, $this->protocolsToChecker)) {
+                return $this->protocolsToChecker[$protocol];
+            } else {
+                throw InvalidArgument::unknowProtocol($protocol);
+            }
+        }
+        return $this->protocolsToChecker;
+    }
+
+    /**
+     * @return CheckerRepository
+     */
+    public static function get()
+    {
+        if (!self::$self instanceof CheckerRepository) {
+            self::$self = new CheckerRepository();
+        }
+        return self::$self;
+    }
+}

--- a/src/Checker/DatabaseChecker.php
+++ b/src/Checker/DatabaseChecker.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: lukaskammerling
+ * Date: 28.11.16
+ * Time: 11:15
+ */
+
+namespace Spatie\UptimeMonitor\Checker;
+
+
+use GuzzleHttp\Psr7\Response;
+use Spatie\UptimeMonitor\Helpers\ConsoleOutput;
+use Spatie\UptimeMonitor\MonitorCollection;
+
+class DatabaseChecker extends Checker
+{
+    /**
+     * @inheritDoc
+     */
+    public function check(MonitorCollection $monitors)
+    {
+        foreach ($monitors as $monitor) {
+            $urlSegments = explode('://', $monitor->url);
+            $protocol = $urlSegments[0];
+            $hostSegments = explode(':', $urlSegments[1]);
+            $host = $hostSegments[0];
+            $port = (array_key_exists(1, $hostSegments)) ? $hostSegments[1] : 3306;
+            \Config::set("database.connections.{$monitor->id}", [
+                'driver' => $protocol,
+                'host' => $host,
+                'port' => $port,
+                'database' => 'monitorDB',
+                'username' => 'monitorUser',
+                'password' => '',
+                'charset' => 'utf8',
+                'collation' => 'utf8_unicode_ci',
+                'prefix' => '',
+                'strict' => true,
+                'engine' => null,
+                'options' => array(
+                    \PDO::ATTR_TIMEOUT => config('laravel-uptime-monitor.uptime_check.timeout_per_connection'),
+                ),
+            ]);
+            ConsoleOutput::info("Checking {$monitor->url}");
+            try {
+                \DB::connection($monitor->id)->reconnect();
+                ConsoleOutput::info("Could reach {$monitor->url}");
+                $monitor->uptimeRequestSucceeded(new Response(200, [], "Could reach {$monitor->url}"));
+            } catch (\Exception $exception) {
+                if (str_contains($exception->getMessage(), 'time')) {
+                    ConsoleOutput::error("Could not reach {$monitor->url} error: `{$exception->getMessage()}`");
+                    $monitor->uptimeRequestFailed($exception->getMessage());
+                } else {
+                    ConsoleOutput::info("Could reach {$monitor->url}");
+                    $monitor->uptimeRequestSucceeded(new Response(200, [], "Could reach {$monitor->url}"));
+                }
+            }
+        }
+    }
+}

--- a/src/Checker/DatabaseChecker.php
+++ b/src/Checker/DatabaseChecker.php
@@ -1,61 +1,76 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: lukaskammerling
- * Date: 28.11.16
- * Time: 11:15
- */
-
 namespace Spatie\UptimeMonitor\Checker;
 
 
+use GuzzleHttp\Promise\EachPromise;
+use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Psr7\Response;
 use Spatie\UptimeMonitor\Helpers\ConsoleOutput;
 use Spatie\UptimeMonitor\MonitorCollection;
 
 class DatabaseChecker extends Checker
 {
+
     /**
      * @inheritDoc
      */
     public function check(MonitorCollection $monitors)
     {
-        foreach ($monitors as $monitor) {
-            $urlSegments = explode('://', $monitor->url);
-            $protocol = $urlSegments[0];
-            $hostSegments = explode(':', $urlSegments[1]);
-            $host = $hostSegments[0];
-            $port = (array_key_exists(1, $hostSegments)) ? $hostSegments[1] : 3306;
-            \Config::set("database.connections.{$monitor->id}", [
-                'driver' => $protocol,
-                'host' => $host,
-                'port' => $port,
-                'database' => 'monitorDB',
-                'username' => 'monitorUser',
-                'password' => '',
-                'charset' => 'utf8',
-                'collation' => 'utf8_unicode_ci',
-                'prefix' => '',
-                'strict' => true,
-                'engine' => null,
-                'options' => array(
-                    \PDO::ATTR_TIMEOUT => config('laravel-uptime-monitor.uptime_check.timeout_per_connection'),
-                ),
-            ]);
-            ConsoleOutput::info("Checking {$monitor->url}");
-            try {
-                \DB::connection($monitor->id)->reconnect();
+        $monitors->resetItemKeys();
+        $this->monitors = $monitors;
+        (new EachPromise($this->getPromises($monitors), [
+            'concurrency' => config('laravel-uptime-monitor.uptime_check.concurrent_checks'),
+            'fulfilled' => function ($monitor, $index) {
+                $monitor = $this->monitors->getMonitorAtIndex($index);
                 ConsoleOutput::info("Could reach {$monitor->url}");
-                $monitor->uptimeRequestSucceeded(new Response(200, [], "Could reach {$monitor->url}"));
-            } catch (\Exception $exception) {
-                if (str_contains($exception->getMessage(), 'time')) {
-                    ConsoleOutput::error("Could not reach {$monitor->url} error: `{$exception->getMessage()}`");
-                    $monitor->uptimeRequestFailed($exception->getMessage());
-                } else {
-                    ConsoleOutput::info("Could reach {$monitor->url}");
+            },
+            'rejected' => function ($exception, $index) {
+                $monitor = $this->monitors->getMonitorAtIndex($index);
+                ConsoleOutput::error("Could not reach {$monitor->url} error: `{$exception->getMessage()}`");
+            },
+        ]))->promise()->wait();
+    }
+
+    protected function getPromises($monitors): \Generator
+    {
+        foreach ($monitors as $monitor) {
+            $promise = with(new Promise())->then(null, function () use (&$promise, $monitor) {
+                $urlSegments = explode('://', $monitor->url);
+                $protocol = $urlSegments[0];
+                $hostSegments = explode(':', $urlSegments[1]);
+                $host = $hostSegments[0];
+                $port = (array_key_exists(1, $hostSegments)) ? $hostSegments[1] : 3306;
+                ConsoleOutput::info("Checking {$monitor->url}");
+                \Config::set("database.connections.{$monitor->id}", [
+                    'driver' => $protocol,
+                    'host' => $host,
+                    'port' => $port,
+                    'database' => 'monitorDB',
+                    'username' => 'monitorUser',
+                    'password' => '',
+                    'charset' => 'utf8',
+                    'collation' => 'utf8_unicode_ci',
+                    'prefix' => '',
+                    'strict' => true,
+                    'engine' => null,
+                    'options' => array(
+                        \PDO::ATTR_TIMEOUT => config('laravel-uptime-monitor.uptime_check.timeout_per_connection'),
+                    ),
+                ]);
+                try {
+                    \DB::connection($monitor->id)->reconnect();
                     $monitor->uptimeRequestSucceeded(new Response(200, [], "Could reach {$monitor->url}"));
+                } catch (\Exception $exception) {
+                    if (str_contains($exception->getMessage(), 'time')) {
+                        $monitor->uptimeRequestFailed($exception->getMessage());
+                    } else {
+                        $monitor->uptimeRequestSucceeded(new Response(200, [], "Could reach {$monitor->url}"));
+                    }
                 }
-            }
+
+            });
+            yield $promise;
         }
+
     }
 }

--- a/src/Checker/HTTPChecker.php
+++ b/src/Checker/HTTPChecker.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: lukaskammerling
+ * Date: 28.11.16
+ * Time: 10:57
+ */
+
+namespace Spatie\UptimeMonitor\Checker;
+
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Promise\EachPromise;
+use Psr\Http\Message\ResponseInterface;
+use Spatie\UptimeMonitor\Helpers\ConsoleOutput;
+use Spatie\UptimeMonitor\MonitorCollection;
+
+class HTTPChecker extends Checker
+{
+    public function check(MonitorCollection $monitors)
+    {
+        $monitors->resetItemKeys();
+        $this->monitors = $monitors;
+        (new EachPromise($this->getPromises($monitors), [
+            'concurrency' => config('laravel-uptime-monitor.uptime_check.concurrent_checks'),
+            'fulfilled' => function (ResponseInterface $response, $index) {
+                $monitor = $this->monitors->getMonitorAtIndex($index);
+
+                ConsoleOutput::info("Could reach {$monitor->url}");
+
+                $monitor->uptimeRequestSucceeded($response);
+            },
+
+            'rejected' => function (RequestException $exception, $index) {
+                $monitor = $this->monitors->getMonitorAtIndex($index);
+                ConsoleOutput::error("Could not reach {$monitor->url} error: `{$exception->getMessage()}`");
+
+                $monitor->uptimeRequestFailed($exception->getMessage());
+            },
+        ]))->promise()->wait();
+    }
+
+    protected function getPromises(MonitorCollection $monitors): \Generator
+    {
+        $client = new Client([
+            'headers' => [
+                'User-Agent' => config('laravel-uptime-monitor.uptime_check.user_agent'),
+            ],
+        ]);
+
+        foreach ($monitors as $monitor) {
+            ConsoleOutput::info("checking {$monitor->url}");
+            $promise = $client->requestAsync(
+                $monitor->uptime_check_method,
+                $monitor->url,
+                ['connect_timeout' => config('laravel-uptime-monitor.uptime_check.timeout_per_site')]
+            );
+
+            yield $promise;
+        }
+    }
+
+
+}

--- a/src/Checker/HTTPChecker.php
+++ b/src/Checker/HTTPChecker.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: lukaskammerling
- * Date: 28.11.16
- * Time: 10:57
- */
-
 namespace Spatie\UptimeMonitor\Checker;
 
 
@@ -31,11 +24,9 @@ class HTTPChecker extends Checker
 
                 $monitor->uptimeRequestSucceeded($response);
             },
-
             'rejected' => function (RequestException $exception, $index) {
                 $monitor = $this->monitors->getMonitorAtIndex($index);
                 ConsoleOutput::error("Could not reach {$monitor->url} error: `{$exception->getMessage()}`");
-
                 $monitor->uptimeRequestFailed($exception->getMessage());
             },
         ]))->promise()->wait();

--- a/src/Checker/SMTPChecker.php
+++ b/src/Checker/SMTPChecker.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: lukaskammerling
+ * Date: 28.11.16
+ * Time: 11:42
+ */
+
+namespace Spatie\UptimeMonitor\Checker;
+
+
+use GuzzleHttp\Psr7\Response;
+use Spatie\UptimeMonitor\Helpers\ConsoleOutput;
+use Spatie\UptimeMonitor\MonitorCollection;
+
+class SMTPChecker extends Checker
+{
+
+    /**
+     * @inheritDoc
+     */
+    public function check(MonitorCollection $monitors)
+    {
+        foreach ($monitors as $monitor) {
+            $urlSegments = explode('://', $monitor->url);
+            $protocol = $urlSegments[0];
+            $hostSegments = explode(':', $urlSegments[1]);
+            $host = $hostSegments[0];
+            $port = (array_key_exists(1, $hostSegments)) ? $hostSegments[1] : 25;
+
+            ConsoleOutput::info("Checking {$monitor->url}");
+            try {
+                $smtpTransport = \Swift_SmtpTransport::newInstance($host, $port);
+                $smtpTransport->setTimeout(config('laravel-uptime-monitor.uptime_check.timeout_per_connection'));
+                $smtpTransport->start();
+                ConsoleOutput::info("Could reach {$monitor->url}");
+                $monitor->uptimeRequestSucceeded(new Response(200, [], "Could reach {$monitor->url}"));
+            } catch (\Exception $exception) {
+                ConsoleOutput::error("Could not reach {$monitor->url} error: `{$exception->getMessage()}`");
+                $monitor->uptimeRequestFailed($exception->getMessage());
+            }
+        }
+    }
+}

--- a/src/Checker/SMTPChecker.php
+++ b/src/Checker/SMTPChecker.php
@@ -1,14 +1,9 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: lukaskammerling
- * Date: 28.11.16
- * Time: 11:42
- */
-
 namespace Spatie\UptimeMonitor\Checker;
 
 
+use GuzzleHttp\Promise\EachPromise;
+use GuzzleHttp\Promise\Promise;
 use GuzzleHttp\Psr7\Response;
 use Spatie\UptimeMonitor\Helpers\ConsoleOutput;
 use Spatie\UptimeMonitor\MonitorCollection;
@@ -21,24 +16,43 @@ class SMTPChecker extends Checker
      */
     public function check(MonitorCollection $monitors)
     {
-        foreach ($monitors as $monitor) {
-            $urlSegments = explode('://', $monitor->url);
-            $protocol = $urlSegments[0];
-            $hostSegments = explode(':', $urlSegments[1]);
-            $host = $hostSegments[0];
-            $port = (array_key_exists(1, $hostSegments)) ? $hostSegments[1] : 25;
-
-            ConsoleOutput::info("Checking {$monitor->url}");
-            try {
-                $smtpTransport = \Swift_SmtpTransport::newInstance($host, $port);
-                $smtpTransport->setTimeout(config('laravel-uptime-monitor.uptime_check.timeout_per_connection'));
-                $smtpTransport->start();
+        $monitors->resetItemKeys();
+        $this->monitors = $monitors;
+        (new EachPromise($this->getPromises($monitors), [
+            'concurrency' => config('laravel-uptime-monitor.uptime_check.concurrent_checks'),
+            'fulfilled' => function ($monitor, $index) {
+                $monitor = $this->monitors->getMonitorAtIndex($index);
                 ConsoleOutput::info("Could reach {$monitor->url}");
                 $monitor->uptimeRequestSucceeded(new Response(200, [], "Could reach {$monitor->url}"));
-            } catch (\Exception $exception) {
+            },
+            'rejected' => function ($exception, $index) {
+                $monitor = $this->monitors->getMonitorAtIndex($index);
                 ConsoleOutput::error("Could not reach {$monitor->url} error: `{$exception->getMessage()}`");
                 $monitor->uptimeRequestFailed($exception->getMessage());
-            }
+            },
+        ]))->promise()->wait();
+    }
+
+    protected function getPromises($monitors): \Generator
+    {
+        foreach ($monitors as $monitor) {
+            $promise = with(new Promise())->then(null, function () use (&$promise, $monitor) {
+                $urlSegments = explode('://', $monitor->url);
+                $protocol = $urlSegments[0];
+                $hostSegments = explode(':', $urlSegments[1]);
+                $host = $hostSegments[0];
+                $port = (array_key_exists(1, $hostSegments)) ? $hostSegments[1] : 25;
+                ConsoleOutput::info("Checking {$monitor->url}");
+                try {
+                    $smtpTransport = \Swift_SmtpTransport::newInstance($host, $port);
+                    $smtpTransport->setTimeout(config('laravel-uptime-monitor.uptime_check.timeout_per_connection'));
+                    $smtpTransport->start();
+                } catch (\Swift_TransportException $e) {
+                    throw new \Exception($e->getMessage());
+                }
+            });
+            yield $promise;
         }
+
     }
 }

--- a/src/Commands/CreateMonitor.php
+++ b/src/Commands/CreateMonitor.php
@@ -15,11 +15,11 @@ class CreateMonitor extends BaseCommand
     {
         $url = Url::fromString($this->argument('url'));
 
-        if (! in_array($url->getScheme(), ['http', 'https'])) {
+       /* if (! in_array($url->getScheme(), ['http', 'https'])) {
             $this->error('The given url did not start with `http://` or `https://`.');
 
             return;
-        }
+        } */
 
         if ($this->confirm('Should we look for a specific string on the response?')) {
             $lookForString = $this->ask('Which string?');

--- a/src/Exceptions/InvalidArgument.php
+++ b/src/Exceptions/InvalidArgument.php
@@ -1,0 +1,21 @@
+<?php
+namespace Spatie\UptimeMonitor\Exceptions;
+
+/**
+ * Class InvalidArgument
+ * @package Spatie\UptimeMonitor\Exceptions
+ */
+class InvalidArgument extends \InvalidArgumentException
+{
+    /**
+     * @param $protocol
+     */
+    public static function unknowProtocol($protocol)
+    {
+        throw new static("We doesn't know anything about the protocol `{$protocol}");
+    }
+
+    public static function checkerAlreadyRegisterd($protocol){
+        throw new static("For the Protocol `{$protocol}` is already an Checker registerd.");
+    }
+}

--- a/src/UptimeMonitorServiceProvider.php
+++ b/src/UptimeMonitorServiceProvider.php
@@ -3,6 +3,10 @@
 namespace Spatie\UptimeMonitor;
 
 use Illuminate\Support\ServiceProvider;
+use Spatie\UptimeMonitor\Checker\CheckerRepository;
+use Spatie\UptimeMonitor\Checker\DatabaseChecker;
+use Spatie\UptimeMonitor\Checker\HTTPChecker;
+use Spatie\UptimeMonitor\Checker\SMTPChecker;
 use Spatie\UptimeMonitor\Commands\CheckCertificates;
 use Spatie\UptimeMonitor\Commands\CheckUptime;
 use Spatie\UptimeMonitor\Commands\CreateMonitor;
@@ -20,19 +24,22 @@ class UptimeMonitorServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        CheckerRepository::get()->addChecker('http*', new HTTPChecker());
+        CheckerRepository::get()->addChecker('mysql', new DatabaseChecker());
+        CheckerRepository::get()->addChecker('smtp', new SMTPChecker());
         if ($this->app->runningInConsole()) {
-            $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+            $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
 
             $this->publishes([
-                __DIR__.'/../config/laravel-uptime-monitor.php' => config_path('laravel-uptime-monitor.php'),
+                __DIR__ . '/../config/laravel-uptime-monitor.php' => config_path('laravel-uptime-monitor.php'),
             ], 'config');
         }
 
-        if (! class_exists('CreateSitesTable')) {
+        if (!class_exists('CreateSitesTable')) {
             $timestamp = date('Y_m_d_His', time());
 
             $this->publishes([
-                __DIR__.'/../database/migrations/create_monitors_table.php.stub' => database_path('migrations/'.$timestamp.'_create_monitors_table.php'),
+                __DIR__ . '/../database/migrations/create_monitors_table.php.stub' => database_path('migrations/' . $timestamp . '_create_monitors_table.php'),
             ], 'migrations');
         }
     }
@@ -42,7 +49,7 @@ class UptimeMonitorServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/laravel-uptime-monitor.php', 'laravel-uptime-monitor');
+        $this->mergeConfigFrom(__DIR__ . '/../config/laravel-uptime-monitor.php', 'laravel-uptime-monitor');
 
         $this->app['events']->subscribe(EventHandler::class);
 


### PR DESCRIPTION
As said in Issuse https://github.com/spatie/laravel-uptime-monitor/issues/50 here is the PR with the other Monitors. In the moment there is mysql & smtp available. With some little work it is possible for Users to make there own "Checkers". The changes required a little refactoring from the Monitoring System.

At the moment there is an issue with Spaties URL Schema: https://github.com/spatie/url/blob/master/src/Url.php#L200-L202

It allows only http & https, not other "url schemas" like smtp://,mysql:// (or ftp://). @freekmurze how do you think about this? Should i remove the Part from URL Schema or should i leave it out? What do you think about it?