### PR TITLE
Tweak notifications

### DIFF
--- a/src/Helpers/Period.php
+++ b/src/Helpers/Period.php
@@ -28,6 +28,10 @@ class Period
     {
         $interval = $this->startDateTime->diff($this->endDateTime);
 
+        if($interval->format('%h') === '0') {
+            return $interval->format('%im');
+        };
+
         return $interval->format('%hh %im');
     }
 

--- a/src/Notifications/Notifications/CertificateCheckSucceeded.php
+++ b/src/Notifications/Notifications/CertificateCheckSucceeded.php
@@ -23,7 +23,6 @@ class CertificateCheckSucceeded extends BaseNotification
     public function toMail($notifiable)
     {
         $mailMessage = (new MailMessage)
-            ->success()
             ->subject($this->getMessageText())
             ->line($this->getMessageText());
 

--- a/src/Notifications/Notifications/CertificateExpiresSoon.php
+++ b/src/Notifications/Notifications/CertificateExpiresSoon.php
@@ -23,6 +23,7 @@ class CertificateExpiresSoon extends BaseNotification
     public function toMail($notifiable)
     {
         $mailMessage = (new MailMessage)
+            ->warning()
             ->subject($this->getMessageText())
             ->line($this->getMessageText());
 
@@ -55,6 +56,6 @@ class CertificateExpiresSoon extends BaseNotification
 
     protected function getMessageText(): string
     {
-        return "{$this->event->monitor->url} has a certificate that will expire soon";
+        return "SSL certificate for {$this->event->monitor->url} expires soon";
     }
 }

--- a/src/Notifications/Notifications/UptimeCheckSucceeded.php
+++ b/src/Notifications/Notifications/UptimeCheckSucceeded.php
@@ -24,7 +24,6 @@ class UptimeCheckSucceeded extends BaseNotification
     public function toMail($notifiable)
     {
         $mailMessage = (new MailMessage)
-            ->success()
             ->subject($this->getMessageText())
             ->line($this->getMessageText());
 
@@ -38,7 +37,6 @@ class UptimeCheckSucceeded extends BaseNotification
     public function toSlack($notifiable)
     {
         return (new SlackMessage)
-            ->success()
             ->attachment(function (SlackAttachment $attachment) {
                 $attachment
                     ->title($this->getMessageText())


### PR DESCRIPTION
- Small textual correction for SSL consistency
- Display downtime in minutes when < 1 hour
- Use Slack green only for recovery (to stand out), use default gray for normal situation in uptime and SSL