### PR TITLE
Remove all laravel-Prefixes from config

### DIFF
--- a/config/uptime-monitor.php
+++ b/config/uptime-monitor.php
@@ -92,7 +92,7 @@ return [
         /*
          * When reaching out to sites this user agent will be used.
          */
-        'user_agent' => 'spatie/laravel-uptime-monitor uptime checker',
+        'user_agent' => 'spatie/uptime-monitor uptime checker',
 
         /*
          * When reaching out to the sites these headers will be added.

--- a/src/Commands/CreateMonitor.php
+++ b/src/Commands/CreateMonitor.php
@@ -30,7 +30,7 @@ class CreateMonitor extends BaseCommand
             'look_for_string' => $lookForString ?? '',
             'uptime_check_method' => isset($lookForString) ? 'get' : 'head',
             'certificate_check_enabled' => $url->getScheme() === 'https',
-            'uptime_check_interval_in_minutes' => config('laravel-uptime-monitor.uptime_check.run_interval_in_minutes'),
+            'uptime_check_interval_in_minutes' => config('uptime-monitor.uptime_check.run_interval_in_minutes'),
         ]);
 
         $this->warn("{$monitor->url} will be monitored!");

--- a/src/Helpers/Period.php
+++ b/src/Helpers/Period.php
@@ -41,7 +41,7 @@ class Period
 
     public function toText(): string
     {
-        $configuredDateFormat = config('laravel-uptime-monitor.notifications.date_format');
+        $configuredDateFormat = config('uptime-monitor.notifications.date_format');
 
         return
             $this->startDateTime->format('H:i').' '

--- a/src/Models/Presenters/MonitorPresenter.php
+++ b/src/Models/Presenters/MonitorPresenter.php
@@ -73,7 +73,7 @@ trait MonitorPresenter
         }
 
         if ($format === '') {
-            $format = config('laravel-uptime-monitor.notifications.date_format');
+            $format = config('uptime-monitor.notifications.date_format');
         }
 
         return $this->$attributeName->format($format);

--- a/src/Models/Traits/SupportsCertificateCheck.php
+++ b/src/Models/Traits/SupportsCertificateCheck.php
@@ -53,7 +53,7 @@ trait SupportsCertificateCheck
         if ($this->certificate_status === CertificateStatus::VALID) {
             event(new CertificateCheckSucceeded($this, $certificate));
 
-            if ($certificate->expirationDate()->diffInDays() <= config('laravel-uptime-monitor.certificate_check.fire_expiring_soon_event_if_certificate_expires_within_days')) {
+            if ($certificate->expirationDate()->diffInDays() <= config('uptime-monitor.certificate_check.fire_expiring_soon_event_if_certificate_expires_within_days')) {
                 event(new CertificateExpiresSoon($monitor, $certificate));
             }
 

--- a/src/Models/Traits/SupportsUptimeCheck.php
+++ b/src/Models/Traits/SupportsUptimeCheck.php
@@ -114,7 +114,7 @@ trait SupportsUptimeCheck
 
     protected function shouldFireUptimeCheckFailedEvent(): bool
     {
-        if ($this->uptime_check_times_failed_in_a_row === config('laravel-uptime-monitor.uptime_check.fire_monitor_failed_event_after_consecutive_failures')) {
+        if ($this->uptime_check_times_failed_in_a_row === config('uptime-monitor.uptime_check.fire_monitor_failed_event_after_consecutive_failures')) {
             return true;
         }
 
@@ -122,11 +122,11 @@ trait SupportsUptimeCheck
             return false;
         }
 
-        if (config('laravel-uptime-monitor.notifications.resend_uptime_check_failed_notification_every_minutes') === 0) {
+        if (config('uptime-monitor.notifications.resend_uptime_check_failed_notification_every_minutes') === 0) {
             return false;
         }
 
-        if ($this->uptime_check_failed_event_fired_on_date->diffInMinutes() >= config('laravel-uptime-monitor.notifications.resend_uptime_check_failed_notification_every_minutes')) {
+        if ($this->uptime_check_failed_event_fired_on_date->diffInMinutes() >= config('uptime-monitor.notifications.resend_uptime_check_failed_notification_every_minutes')) {
             return true;
         }
 

--- a/src/MonitorCollection.php
+++ b/src/MonitorCollection.php
@@ -28,7 +28,7 @@ class MonitorCollection extends Collection
         $this->resetItemKeys();
 
         (new EachPromise($this->getPromises(), [
-            'concurrency' => config('laravel-uptime-monitor.uptime_check.concurrent_checks'),
+            'concurrency' => config('uptime-monitor.uptime_check.concurrent_checks'),
             'fulfilled' => function (ResponseInterface $response, $index) {
                 $monitor = $this->getMonitorAtIndex($index);
 
@@ -51,8 +51,8 @@ class MonitorCollection extends Collection
     {
         // client headers
         $headers = array_merge(
-            ['User-Agent' => config('laravel-uptime-monitor.uptime_check.user_agent')],
-            config('laravel-uptime-monitor.uptime_check.additional_headers') ?? []
+            ['User-Agent' => config('uptime-monitor.uptime_check.user_agent')],
+            config('uptime-monitor.uptime_check.additional_headers') ?? []
         );
 
         $client = new Client([
@@ -64,7 +64,7 @@ class MonitorCollection extends Collection
             $promise = $client->requestAsync(
                 $monitor->uptime_check_method,
                 $monitor->url,
-                ['connect_timeout' => config('laravel-uptime-monitor.uptime_check.timeout_per_site')]
+                ['connect_timeout' => config('uptime-monitor.uptime_check.timeout_per_site')]
             );
 
             yield $promise;

--- a/src/MonitorRepository.php
+++ b/src/MonitorRepository.php
@@ -120,7 +120,7 @@ class MonitorRepository
 
     protected static function determineMonitorModel(): string
     {
-        $monitorModel = config('laravel-uptime-monitor.monitor_model') ?? Monitor::class;
+        $monitorModel = config('uptime-monitor.monitor_model') ?? Monitor::class;
 
         if (! is_a($monitorModel, Monitor::class, true)) {
             throw InvalidConfiguration::modelIsNotValid($monitorModel);

--- a/src/Notifications/BaseNotification.php
+++ b/src/Notifications/BaseNotification.php
@@ -16,7 +16,7 @@ abstract class BaseNotification extends Notification
      */
     public function via($notifiable)
     {
-        return config('laravel-uptime-monitor.notifications.notifications.'.static::class);
+        return config('uptime-monitor.notifications.notifications.'.static::class);
     }
 
     public function getMonitor(): Monitor
@@ -42,7 +42,7 @@ abstract class BaseNotification extends Notification
 
     public function getLocationDescription(): string
     {
-        $configuredLocation = config('laravel-uptime-monitor.notifications.location');
+        $configuredLocation = config('uptime-monitor.notifications.location');
 
         if ($configuredLocation == '') {
             return '';

--- a/src/Notifications/EventHandler.php
+++ b/src/Notifications/EventHandler.php
@@ -40,7 +40,7 @@ class EventHandler
 
     protected function determineNotifiable()
     {
-        $notifiableClass = $this->config->get('laravel-uptime-monitor.notifications.notifiable');
+        $notifiableClass = $this->config->get('uptime-monitor.notifications.notifiable');
 
         return app($notifiableClass);
     }
@@ -49,7 +49,7 @@ class EventHandler
     {
         $eventName = class_basename($event);
 
-        $notificationClass = collect($this->config->get('laravel-uptime-monitor.notifications.notifications'))
+        $notificationClass = collect($this->config->get('uptime-monitor.notifications.notifications'))
             ->filter(function (array $notificationChannels) {
                 return count($notificationChannels);
             })

--- a/src/Notifications/Notifiable.php
+++ b/src/Notifications/Notifiable.php
@@ -13,7 +13,7 @@ class Notifiable
      */
     public function routeNotificationForMail()
     {
-        return config('laravel-uptime-monitor.notifications.mail.to');
+        return config('uptime-monitor.notifications.mail.to');
     }
 
     /**
@@ -21,7 +21,7 @@ class Notifiable
      */
     public function routeNotificationForSlack()
     {
-        return config('laravel-uptime-monitor.notifications.slack.webhook_url');
+        return config('uptime-monitor.notifications.slack.webhook_url');
     }
 
     public function getKey(): string

--- a/src/UptimeMonitorServiceProvider.php
+++ b/src/UptimeMonitorServiceProvider.php
@@ -24,7 +24,7 @@ class UptimeMonitorServiceProvider extends ServiceProvider
             $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
 
             $this->publishes([
-                __DIR__.'/../config/laravel-uptime-monitor.php' => config_path('laravel-uptime-monitor.php'),
+                __DIR__.'/../config/uptime-monitor.php' => config_path('uptime-monitor.php'),
             ], 'config');
         }
 
@@ -42,7 +42,7 @@ class UptimeMonitorServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/laravel-uptime-monitor.php', 'laravel-uptime-monitor');
+        $this->mergeConfigFrom(__DIR__.'/../config/uptime-monitor.php', 'uptime-monitor');
 
         $this->app['events']->subscribe(EventHandler::class);
 
@@ -56,7 +56,7 @@ class UptimeMonitorServiceProvider extends ServiceProvider
 
         $this->app->bind(
             UptimeResponseChecker::class,
-            config('laravel-uptime-monitor.uptime_check.response_checker')
+            config('uptime-monitor.uptime_check.response_checker')
         );
 
         $this->commands([

--- a/tests/Integration/ConfigurationTest.php
+++ b/tests/Integration/ConfigurationTest.php
@@ -17,7 +17,7 @@ class ConfigurationTest extends TestCase
             public $table = 'monitors';
         };
 
-        $this->app['config']->set('laravel-uptime-monitor.monitor_model', get_class($customModel));
+        $this->app['config']->set('uptime-monitor.monitor_model', get_class($customModel));
 
         $this->assertInstanceOf(get_class($customModel), MonitorRepository::getEnabled()->first());
     }
@@ -28,7 +28,7 @@ class ConfigurationTest extends TestCase
         $customModel = new class {
         };
 
-        $this->app['config']->set('laravel-uptime-monitor.monitor_model', get_class($customModel));
+        $this->app['config']->set('uptime-monitor.monitor_model', get_class($customModel));
 
         $this->expectException(InvalidConfiguration::class);
 

--- a/tests/Integration/Events/UptimeCheckFailedTest.php
+++ b/tests/Integration/Events/UptimeCheckFailedTest.php
@@ -31,7 +31,7 @@ class UptimeCheckFailedTest extends TestCase
 
         $monitors = MonitorRepository::getForUptimeCheck();
 
-        $consecutiveFailsNeeded = config('laravel-uptime-monitor.uptime_check.fire_monitor_failed_event_after_consecutive_failures');
+        $consecutiveFailsNeeded = config('uptime-monitor.uptime_check.fire_monitor_failed_event_after_consecutive_failures');
 
         foreach (range(1, $consecutiveFailsNeeded) as $index) {
             $monitors->checkUptime();
@@ -53,7 +53,7 @@ class UptimeCheckFailedTest extends TestCase
 
         $monitors = MonitorRepository::getForUptimeCheck();
 
-        $consecutiveFailsNeeded = config('laravel-uptime-monitor.uptime_check.fire_monitor_failed_event_after_consecutive_failures');
+        $consecutiveFailsNeeded = config('uptime-monitor.uptime_check.fire_monitor_failed_event_after_consecutive_failures');
 
         foreach (range(1, $consecutiveFailsNeeded) as $index) {
             $monitors->checkUptime();
@@ -73,7 +73,7 @@ class UptimeCheckFailedTest extends TestCase
 
         $this->resetEventAssertions();
 
-        $this->progressMinutes(config('laravel-uptime-monitor.notifications.resend_uptime_check_failed_notification_every_minutes'));
+        $this->progressMinutes(config('uptime-monitor.notifications.resend_uptime_check_failed_notification_every_minutes'));
 
         $monitors->checkUptime();
 
@@ -88,7 +88,7 @@ class UptimeCheckFailedTest extends TestCase
         $this->monitor->look_for_string = 'Another page';
         $this->monitor->save();
 
-        $this->app['config']->set('laravel-uptime-monitor.uptime_check.fire_monitor_failed_event_after_consecutive_failures', 1);
+        $this->app['config']->set('uptime-monitor.uptime_check.fire_monitor_failed_event_after_consecutive_failures', 1);
 
         MonitorRepository::getForUptimeCheck()->checkUptime();
 

--- a/tests/Integration/Events/UptimeCheckRecoveredTest.php
+++ b/tests/Integration/Events/UptimeCheckRecoveredTest.php
@@ -30,7 +30,7 @@ class UptimeCheckRecoveredTest extends TestCase
 
         $this->server->down();
 
-        $consecutiveFailsNeeded = config('laravel-uptime-monitor.uptime_check.fire_monitor_failed_event_after_consecutive_failures');
+        $consecutiveFailsNeeded = config('uptime-monitor.uptime_check.fire_monitor_failed_event_after_consecutive_failures');
 
         foreach (range(1, $consecutiveFailsNeeded) as $index) {
             $monitors->checkUptime();

--- a/tests/Integration/Models/Traits/SupportsUptimeCheckTest.php
+++ b/tests/Integration/Models/Traits/SupportsUptimeCheckTest.php
@@ -24,7 +24,7 @@ class SupportsUptimeCheckTest extends TestCase
     {
         $this->assertFalse($this->monitor->shouldCheckUptime());
 
-        $this->progressMinutes(config('laravel-uptime-monitor.uptime_check.run_interval_in_minutes') - 1);
+        $this->progressMinutes(config('uptime-monitor.uptime_check.run_interval_in_minutes') - 1);
 
         $this->assertFalse($this->monitor->shouldCheckUptime());
 

--- a/tests/Integration/Notifications/EventHandlerTest.php
+++ b/tests/Integration/Notifications/EventHandlerTest.php
@@ -42,7 +42,7 @@ class EventHandlerTest extends TestCase
         $shouldSendNotification
     ) {
         $this->app['config']->set(
-            'laravel-uptime-monitor.notifications.notifications.'.UptimeCheckSucceeded::class,
+            'uptime-monitor.notifications.notifications.'.UptimeCheckSucceeded::class,
             ['slack']
         );
 
@@ -110,7 +110,7 @@ class EventHandlerTest extends TestCase
     public function it_send_notifications_to_the_channels_configured_in_the_config_file(array $configuredChannels)
     {
         $this->app['config']->set(
-            'laravel-uptime-monitor.notifications.notifications.'.UptimeCheckSucceeded::class,
+            'uptime-monitor.notifications.notifications.'.UptimeCheckSucceeded::class,
             $configuredChannels
         );
 

--- a/tests/factories/MonitorFactory.php
+++ b/tests/factories/MonitorFactory.php
@@ -7,7 +7,7 @@ $factory->define(Monitor::class, function (Faker\Generator $faker) {
     return [
         'url' => 'http://localhost:8080',
         'uptime_status' => UptimeStatus::UP,
-        'uptime_check_interval_in_minutes' => config('laravel-uptime-monitor.uptime_check.run_interval_in_minutes'),
+        'uptime_check_interval_in_minutes' => config('uptime-monitor.uptime_check.run_interval_in_minutes'),
         'uptime_check_enabled' => true,
         'certificate_check_enabled' => false,
     ];


### PR DESCRIPTION
As said in https://github.com/spatie/laravel-medialibrary/issues/467 you planed to remove the laravel-prefix on all your packages, so this is the next pr for your wish :)