### PR TITLE
Changing warning to error for CertificateExpiresSoon email notification

### DIFF
--- a/src/Notifications/Notifications/CertificateExpiresSoon.php
+++ b/src/Notifications/Notifications/CertificateExpiresSoon.php
@@ -23,7 +23,7 @@ class CertificateExpiresSoon extends BaseNotification
     public function toMail($notifiable)
     {
         $mailMessage = (new MailMessage)
-            ->warning()
+            ->error()
             ->subject($this->getMessageText())
             ->line($this->getMessageText());
 


### PR DESCRIPTION
For my Laravel 5.4 deployment, I didn't have a `warning()` method I could call on `MailMessage` so I changed it to `error()` to avoid this issue