### PR TITLE
Remove redundant where clause

### DIFF
--- a/src/MonitorRepository.php
+++ b/src/MonitorRepository.php
@@ -89,11 +89,6 @@ class MonitorRepository
                     ->where('uptime_check_enabled', true)
                     ->where('uptime_status', UptimeStatus::NOT_YET_CHECKED);
             })
-            ->orWhere(function (Builder $query) {
-                $query
-                    ->where('uptime_check_enabled', true)
-                    ->where('uptime_status', UptimeStatus::NOT_YET_CHECKED);
-            })
             ->get();
 
         return MonitorCollection::make($monitors)->sortByHost();

--- a/src/MonitorRepository.php
+++ b/src/MonitorRepository.php
@@ -89,6 +89,11 @@ class MonitorRepository
                     ->where('uptime_check_enabled', true)
                     ->where('uptime_status', UptimeStatus::NOT_YET_CHECKED);
             })
+            ->orWhere(function (Builder $query) {
+                $query
+                    ->where('certificate_check_enabled', true)
+                    ->where('certificate_status', CertificateStatus::NOT_YET_CHECKED);
+            })
             ->get();
 
         return MonitorCollection::make($monitors)->sortByHost();

--- a/tests/Integration/MonitorRepositoryTest.php
+++ b/tests/Integration/MonitorRepositoryTest.php
@@ -51,6 +51,52 @@ class MonitorRepositoryTest extends TestCase
     }
 
     /** @test */
+    function it_can_get_all_unchecked_monitors()
+    {
+        Monitor::create(['url' => 'http://down1.com', 'uptime_status' => UptimeStatus::DOWN]);
+
+        Monitor::create(['url' => 'http://up.com', 'uptime_status' => UptimeStatus::UP]);
+
+        Monitor::create([
+            'url' => 'http://checked.com',
+            'uptime_status' => UptimeStatus::UP,
+            'certificate_status' => CertificateStatus::VALID
+        ]);
+
+        Monitor::create([
+            'url' => 'http://unchecked1.com',
+            'uptime_status' => UptimeStatus::UP,
+            'certificate_check_enabled' => true,
+            'certificate_status' => CertificateStatus::NOT_YET_CHECKED
+        ]);
+
+        Monitor::create([
+            'url' => 'http://unchecked2.com',
+            'uptime_status' => UptimeStatus::NOT_YET_CHECKED,
+            'certificate_check_enabled' => true,
+            'certificate_status' => CertificateStatus::NOT_YET_CHECKED
+        ]);
+
+        Monitor::create([
+            'url' => 'http://disabled1.com',
+            'uptime_status' => UptimeStatus::NOT_YET_CHECKED,
+            'uptime_check_enabled' => false,
+            'certificate_status' => CertificateStatus::NOT_YET_CHECKED
+        ]);
+
+        Monitor::create([
+            'url' => 'http://enabled.com',
+            'uptime_status' => UptimeStatus::NOT_YET_CHECKED,
+            'uptime_check_enabled' => false,
+            'certificate_status' => CertificateStatus::NOT_YET_CHECKED,
+            'certificate_check_enabled' => true,
+        ]);
+
+        $uncheckedMonitors = MonitorRepository::getUnchecked();
+        $this->assertEquals(['http://enabled.com', 'http://unchecked1.com', 'http://unchecked2.com'], $this->getMonitorUrls($uncheckedMonitors));
+    }
+
+    /** @test */
     public function it_can_get_all_monitors_that_are_failing()
     {
         Monitor::create(['url' => 'http://down1.com', 'uptime_status' => UptimeStatus::DOWN]);

--- a/tests/Integration/MonitorRepositoryTest.php
+++ b/tests/Integration/MonitorRepositoryTest.php
@@ -51,7 +51,7 @@ class MonitorRepositoryTest extends TestCase
     }
 
     /** @test */
-    function it_can_get_all_unchecked_monitors()
+    public function it_can_get_all_unchecked_monitors()
     {
         Monitor::create(['url' => 'http://down1.com', 'uptime_status' => UptimeStatus::DOWN]);
 
@@ -60,28 +60,28 @@ class MonitorRepositoryTest extends TestCase
         Monitor::create([
             'url' => 'http://checked.com',
             'uptime_status' => UptimeStatus::UP,
-            'certificate_status' => CertificateStatus::VALID
+            'certificate_status' => CertificateStatus::VALID,
         ]);
 
         Monitor::create([
             'url' => 'http://unchecked1.com',
             'uptime_status' => UptimeStatus::UP,
             'certificate_check_enabled' => true,
-            'certificate_status' => CertificateStatus::NOT_YET_CHECKED
+            'certificate_status' => CertificateStatus::NOT_YET_CHECKED,
         ]);
 
         Monitor::create([
             'url' => 'http://unchecked2.com',
             'uptime_status' => UptimeStatus::NOT_YET_CHECKED,
             'certificate_check_enabled' => true,
-            'certificate_status' => CertificateStatus::NOT_YET_CHECKED
+            'certificate_status' => CertificateStatus::NOT_YET_CHECKED,
         ]);
 
         Monitor::create([
             'url' => 'http://disabled1.com',
             'uptime_status' => UptimeStatus::NOT_YET_CHECKED,
             'uptime_check_enabled' => false,
-            'certificate_status' => CertificateStatus::NOT_YET_CHECKED
+            'certificate_status' => CertificateStatus::NOT_YET_CHECKED,
         ]);
 
         Monitor::create([


### PR DESCRIPTION
Unless I'm missing something, `orWhere` is either redundant or we wanted to check `certificate_status` instead. Something like:

```php
orWhere(function (Builder $query) {
                $query
                    ->where('certificate_check_enabled', true)
                    ->where('certificate_status', CertificateStatus::NOT_YET_CHECKED);
            })

```
If we meant to check certificate status, I can send another pull request.