### PR TITLE
Add required field `uptime_status_last_change_date` to test Monitor factory

### DIFF
--- a/tests/factories/MonitorFactory.php
+++ b/tests/factories/MonitorFactory.php
@@ -1,5 +1,6 @@
 <?php
 
+use Carbon\Carbon;
 use Spatie\UptimeMonitor\Models\Monitor;
 use Spatie\UptimeMonitor\Models\Enums\UptimeStatus;
 
@@ -8,6 +9,7 @@ $factory->define(Monitor::class, function (Faker\Generator $faker) {
         'url' => 'http://localhost:8080',
         'uptime_status' => UptimeStatus::UP,
         'uptime_check_interval_in_minutes' => config('laravel-uptime-monitor.uptime_check.run_interval_in_minutes'),
+        'uptime_status_last_change_date' => Carbon::now(),
         'uptime_check_enabled' => true,
         'certificate_check_enabled' => false,
     ];


### PR DESCRIPTION
Normally this field is set on the `saving` event of the Monitor model but this is not the case when using factories