### PR TITLE
Updated config to show `mail.to` as an array

### DIFF
--- a/config/laravel-uptime-monitor.php
+++ b/config/laravel-uptime-monitor.php
@@ -31,7 +31,7 @@ return [
         'resend_uptime_check_failed_notification_every_minutes' => 60,
 
         'mail' => [
-            'to' => 'your@email.com',
+            'to' => ['your@email.com'],
         ],
 
         'slack' => [


### PR DESCRIPTION
Laravel will already send the mail to all addresses in the array (see https://github.com/laravel/framework/blob/master/src/Illuminate/Notifications/Channels/MailChannel.php#L153).

(tested with the mailgun driver)