### PR TITLE
Avoid false positive by retries in http client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": "^7.0",
+        "graham-campbell/guzzle-factory": "^2.1",
         "guzzlehttp/guzzle": "^6.2",
         "illuminate/console": "~5.4.0",
         "illuminate/database": "~5.4.0",

--- a/config/laravel-uptime-monitor.php
+++ b/config/laravel-uptime-monitor.php
@@ -116,4 +116,10 @@ return [
      * `Spatie\UptimeMonitor\Models\Monitor`.
      */
     'monitor_model' => Spatie\UptimeMonitor\Models\Monitor::class,
+
+    /*
+     * The delay in ms for retrying connection to a website.
+     * Decrease this value to speed up the verification process.
+     */
+    'backoff_delay' => 200,
 ];

--- a/src/MonitorCollection.php
+++ b/src/MonitorCollection.php
@@ -3,7 +3,7 @@
 namespace Spatie\UptimeMonitor;
 
 use Generator;
-use GuzzleHttp\Client;
+use GrahamCampbell\GuzzleFactory\GuzzleFactory;
 use Illuminate\Support\Collection;
 use GuzzleHttp\Promise\EachPromise;
 use Psr\Http\Message\ResponseInterface;
@@ -55,9 +55,9 @@ class MonitorCollection extends Collection
             config('laravel-uptime-monitor.uptime_check.additional_headers') ?? []
         );
 
-        $client = new Client([
+        $client = GuzzleFactory::make([
             'headers' => $headers,
-        ]);
+        ], config('laravel-uptime-monitor.backoff_delay', 200));
 
         foreach ($this->items as $monitor) {
             ConsoleOutput::info("Checking {$monitor->url}");

--- a/src/MonitorCollection.php
+++ b/src/MonitorCollection.php
@@ -3,7 +3,7 @@
 namespace Spatie\UptimeMonitor;
 
 use Generator;
-use GrahamCampbell\GuzzleFactory\GuzzleFactory;
+use GuzzleHttp\Client;
 use Illuminate\Support\Collection;
 use GuzzleHttp\Promise\EachPromise;
 use Psr\Http\Message\ResponseInterface;
@@ -55,16 +55,17 @@ class MonitorCollection extends Collection
             config('laravel-uptime-monitor.uptime_check.additional_headers') ?? []
         );
 
-        $client = GuzzleFactory::make([
-            'headers' => $headers,
-        ], config('laravel-uptime-monitor.backoff_delay', 200));
+        $client = app()->make('http.client');
 
         foreach ($this->items as $monitor) {
             ConsoleOutput::info("Checking {$monitor->url}");
             $promise = $client->requestAsync(
                 $monitor->uptime_check_method,
                 $monitor->url,
-                ['connect_timeout' => config('laravel-uptime-monitor.uptime_check.timeout_per_site')]
+                [
+                    'connect_timeout' => config('laravel-uptime-monitor.uptime_check.timeout_per_site'),
+                    'headers' => $headers,
+                ]
             );
 
             yield $promise;

--- a/src/UptimeMonitorServiceProvider.php
+++ b/src/UptimeMonitorServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\UptimeMonitor;
 
+use GrahamCampbell\GuzzleFactory\GuzzleFactory;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\ServiceProvider;
 use Spatie\UptimeMonitor\Commands\SyncFile;
 use Spatie\UptimeMonitor\Commands\CheckUptime;
@@ -55,6 +57,9 @@ class UptimeMonitorServiceProvider extends ServiceProvider
         $this->app->bind('command.monitor:enable', EnableMonitor::class);
         $this->app->bind('command.monitor:disable', DisableMonitor::class);
         $this->app->bind('command.monitor:list', ListMonitors::class);
+        $this->app->singleton('http.client', function (Container $app) {
+            return GuzzleFactory::make([], config('laravel-uptime-monitor.backoff_delay', 200));
+        });
 
         $this->app->bind(
             UptimeResponseChecker::class,


### PR DESCRIPTION
To avoid false positive in request such as instant curl error (e.g: resolving error because of shitty DNS) I've added a good client factory for guzzle client with some good practices.

It implements the [exponential backoff algorithm](https://developers.google.com/api-client-library/java/google-http-java-client/backoff) with 3 retries to ensure that our servers always throw a 5xx error or if the server can be resolved by DNS.

It can increase the analysis time (according to `RETRY_DELAY` var). I can add it to config file if needed