### PR TITLE
Fix docbloc for variable type hinting

### DIFF
--- a/src/Notifications/Notifications/CertificateCheckFailed.php
+++ b/src/Notifications/Notifications/CertificateCheckFailed.php
@@ -11,7 +11,7 @@ use Spatie\UptimeMonitor\Events\CertificateCheckFailed as InValidCertificateFoun
 
 class CertificateCheckFailed extends BaseNotification
 {
-    /** @var \Spatie\UptimeMonitor\Events\CertificateCheckSucceeded */
+    /** @var \Spatie\UptimeMonitor\Events\CertificateCheckFailed */
     public $event;
 
     /**


### PR DESCRIPTION
Noticed this as I was extending the class. Figured I'd throw up a PR with a fix.