### PR TITLE
Updated to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "spatie/url": "^1.0.1"
     },
     "require-dev": {
-        "mockery/mockery": "0.9.5",
+        "mockery/mockery": "^1.0",
         "orchestra/testbench": "~3.5.0",
         "phpunit/phpunit": "^6.3"
     },


### PR DESCRIPTION
Updated `mockery/mockery` to [`^1.0`](https://github.com/mockery/mockery/releases/tag/1.0).

PS: I won't apply [this](https://styleci.io/analyses/qBQOkO) StyleCI changes. There are not related to this PR :sweat_smile: 