### PR TITLE
Add ability to send a payload

### DIFF
--- a/database/migrations/create_monitors_table.php.stub
+++ b/database/migrations/create_monitors_table.php.stub
@@ -28,6 +28,8 @@ class CreateMonitorsTable extends Migration
             $table->timestamp('uptime_last_check_date')->nullable();
             $table->timestamp('uptime_check_failed_event_fired_on_date')->nullable();
             $table->string('uptime_check_method')->default('get');
+            $table->text('uptime_check_payload')->nullable();
+            $table->string('uptime_check_payload_content_type')->nullable();
 
             $table->boolean('certificate_check_enabled')->default(false);
             $table->string('certificate_status')->default(CertificateStatus::NOT_YET_CHECKED);

--- a/database/migrations/create_monitors_table.php.stub
+++ b/database/migrations/create_monitors_table.php.stub
@@ -29,7 +29,7 @@ class CreateMonitorsTable extends Migration
             $table->timestamp('uptime_check_failed_event_fired_on_date')->nullable();
             $table->string('uptime_check_method')->default('get');
             $table->text('uptime_check_payload')->nullable();
-            $table->string('uptime_check_payload_content_type')->nullable();
+            $table->text('uptime_check_additional_headers')->nullable();
 
             $table->boolean('certificate_check_enabled')->default(false);
             $table->string('certificate_status')->default(CertificateStatus::NOT_YET_CHECKED);

--- a/src/Models/Monitor.php
+++ b/src/Models/Monitor.php
@@ -31,7 +31,8 @@ class Monitor extends Model
         'certificate_check_enabled' => 'boolean',
     ];
 
-    public function getUptimeCheckAdditionalHeadersAttribute($additionalHeaders) {
+    public function getUptimeCheckAdditionalHeadersAttribute($additionalHeaders)
+    {
         return $additionalHeaders
             ? json_decode($additionalHeaders, true)
             : [];

--- a/src/Models/Monitor.php
+++ b/src/Models/Monitor.php
@@ -31,6 +31,17 @@ class Monitor extends Model
         'certificate_check_enabled' => 'boolean',
     ];
 
+    public function getUptimeCheckAdditionalHeadersAttribute($additionalHeaders) {
+        return $additionalHeaders
+            ? json_decode($additionalHeaders, true)
+            : [];
+    }
+
+    public function setUptimeCheckAdditionalHeadersAttribute(array $additionalHeaders)
+    {
+        $this->attributes['uptime_check_additional_headers'] = json_encode($additionalHeaders);
+    }
+
     public function scopeEnabled($query)
     {
         return $query

--- a/src/MonitorCollection.php
+++ b/src/MonitorCollection.php
@@ -3,7 +3,6 @@
 namespace Spatie\UptimeMonitor;
 
 use Generator;
-use GuzzleHttp\Client;
 use Illuminate\Support\Collection;
 use GuzzleHttp\Promise\EachPromise;
 use Psr\Http\Message\ResponseInterface;

--- a/src/MonitorCollection.php
+++ b/src/MonitorCollection.php
@@ -53,12 +53,16 @@ class MonitorCollection extends Collection
 
         foreach ($this->items as $monitor) {
             ConsoleOutput::info("Checking {$monitor->url}");
+
             $promise = $client->requestAsync(
                 $monitor->uptime_check_method,
                 $monitor->url,
                 [
                     'connect_timeout' => config('uptime-monitor.uptime_check.timeout_per_site'),
-                    'headers' => $headers,
+                    'headers' => array_merge($headers, [
+                        'Content-Type' => $monitor->uptime_check_payload_content_type,
+                    ]),
+                    'body' => $monitor->uptime_check_payload,
                 ]
             );
 

--- a/src/MonitorCollection.php
+++ b/src/MonitorCollection.php
@@ -40,12 +40,6 @@ class MonitorCollection extends Collection
 
     protected function getPromises(): Generator
     {
-        // client headers
-        $headers = array_merge(
-            ['User-Agent' => config('uptime-monitor.uptime_check.user_agent')],
-            config('uptime-monitor.uptime_check.additional_headers') ?? []
-        );
-
         $client = GuzzleFactory::make(
             compact('headers'),
             config('uptime-monitor.uptime-check.retry_connection_after_milliseconds', 100)
@@ -59,15 +53,22 @@ class MonitorCollection extends Collection
                 $monitor->url,
                 [
                     'connect_timeout' => config('uptime-monitor.uptime_check.timeout_per_site'),
-                    'headers' => array_merge($headers, [
-                        'Content-Type' => $monitor->uptime_check_payload_content_type,
-                    ]),
+                    'headers' => $this->promiseHeaders($monitor),
                     'body' => $monitor->uptime_check_payload,
                 ]
             );
 
             yield $promise;
         }
+    }
+
+    private function promiseHeaders(Monitor $monitor)
+    {
+        return collect([])
+            ->merge(['User-Agent' => config('uptime-monitor.uptime_check.user_agent')])
+            ->merge(config('uptime-monitor.uptime_check.additional_headers') ?? [])
+            ->merge($monitor->uptime_check_additional_headers)
+            ->toArray();
     }
 
     /**

--- a/src/MonitorCollection.php
+++ b/src/MonitorCollection.php
@@ -51,11 +51,11 @@ class MonitorCollection extends Collection
             $promise = $client->requestAsync(
                 $monitor->uptime_check_method,
                 $monitor->url,
-                [
+                array_filter([
                     'connect_timeout' => config('uptime-monitor.uptime_check.timeout_per_site'),
                     'headers' => $this->promiseHeaders($monitor),
                     'body' => $monitor->uptime_check_payload,
-                ]
+                ])
             );
 
             yield $promise;

--- a/tests/Integration/Commands/CheckUptimeCommandTest.php
+++ b/tests/Integration/Commands/CheckUptimeCommandTest.php
@@ -74,7 +74,7 @@ class CheckUptimeCommandTest extends TestCase
             'uptime_check_method' => 'post',
             'uptime_check_payload' => json_encode(['foo' => 'bar']),
             'uptime_check_additional_headers' => ['Content-Type' => 'application/json'],
-            'uptime_status' => UptimeStatus::NOT_YET_CHECKED
+            'uptime_status' => UptimeStatus::NOT_YET_CHECKED,
         ]);
 
         Artisan::call('monitor:check-uptime');

--- a/tests/Integration/Commands/CheckUptimeCommandTest.php
+++ b/tests/Integration/Commands/CheckUptimeCommandTest.php
@@ -73,7 +73,7 @@ class CheckUptimeCommandTest extends TestCase
             'url' => sprintf('http://localhost:%s/testPost', env('TEST_SERVER_PORT')),
             'uptime_check_method' => 'post',
             'uptime_check_payload' => json_encode(['foo' => 'bar']),
-            'uptime_check_payload_content_type' => 'application/json',
+            'uptime_check_additional_headers' => ['Content-Type' => 'application/json'],
             'uptime_status' => UptimeStatus::NOT_YET_CHECKED
         ]);
 

--- a/tests/Integration/Commands/CheckUptimeCommandTest.php
+++ b/tests/Integration/Commands/CheckUptimeCommandTest.php
@@ -65,4 +65,22 @@ class CheckUptimeCommandTest extends TestCase
         $this->assertEquals(UptimeStatus::UP, $monitor2->uptime_status);
         $this->assertEquals(UptimeStatus::NOT_YET_CHECKED, $monitor3->uptime_status);
     }
+
+    /** @test */
+    public function it_can_post_a_payload()
+    {
+        $monitor = factory(Monitor::class)->create([
+            'url' => sprintf('http://localhost:%s/testPost', env('TEST_SERVER_PORT')),
+            'uptime_check_method' => 'post',
+            'uptime_check_payload' => json_encode(['foo' => 'bar']),
+            'uptime_check_payload_content_type' => 'application/json',
+            'uptime_status' => UptimeStatus::NOT_YET_CHECKED
+        ]);
+
+        Artisan::call('monitor:check-uptime');
+
+        $monitor = $monitor->fresh();
+
+        $this->assertEquals(UptimeStatus::UP, $monitor->uptime_status);
+    }
 }

--- a/tests/server/public/index.php
+++ b/tests/server/public/index.php
@@ -26,6 +26,14 @@ $app->post('/setServerResponse', function (Request $request) use ($storagePath) 
     file_put_contents($storagePath, $response);
 });
 
+$app->post('/testPost', function (Request $request) {
+    if ($request->get('foo') !== 'bar' && $request->header('Content-Type') !== 'application/json') {
+        return response(null, 500);
+    }
+
+    return response(null, 200);
+});
+
 $app->get('booted', function () {
     return 'app has booted';
 });


### PR DESCRIPTION
This PR adds the ability to send a custom payload to a monitored endpoint. I'm really open to feedback and collaboration on this. I'm totally ok with a "this is pretty custom, you should implement this yourself" as a response.

For perspective, my particular use case is monitoring that an XML service to not only ensure that it is online but also verifying some details in the response body (it has some downstream dependencies that I also need to check against).

A usage example:

1. Update the `uptime_check_get_method` per the [advanced usage documentation](https://docs.spatie.be/laravel-uptime-monitor/v3/advanced-usage/manually-modifying-monitors) to `POST`
1. Update the `uptime_check_payload` column with the request body e.g. `{"foo":"bar"}`
1. Update the `uptime_check_additional_headers` column to include the content type and some authentication headers e.g. `{"Content-Type":"application\/json","Api-Token":"oFfnH0krEmjWP4Mu"}`


## Documentation
If this PR is approved I can open a PR to the documentation repository and make usage updates there.

## FAQ
**How would you verify the response body?**
You can verify the payload by defining your own custom response checker to verify the response body.

**Why did you add a column for additional headers?**
I will likely need to send custom authentication headers along with different monitors.

**Why not a JSON column for the headers?**
I didn't want to break support for current users that might be using a database that does not support JSON columns e.g. MariaDB, SQLite.

**Why not a JSON column for request body?**
In addition to database compatibility issues, not all content bodies are JSON. I regularly have to interface with an XML API that I need to monitor.