### PR TITLE
Adds ability for monitors to have response checkers

### DIFF
--- a/database/migrations/create_monitors_table.php.stub
+++ b/database/migrations/create_monitors_table.php.stub
@@ -30,6 +30,7 @@ class CreateMonitorsTable extends Migration
             $table->string('uptime_check_method')->default('get');
             $table->text('uptime_check_payload')->nullable();
             $table->text('uptime_check_additional_headers')->nullable();
+            $table->string('uptime_check_response_checker')->nullable();
 
             $table->boolean('certificate_check_enabled')->default(false);
             $table->string('certificate_status')->default(CertificateStatus::NOT_YET_CHECKED);

--- a/src/Models/Monitor.php
+++ b/src/Models/Monitor.php
@@ -115,7 +115,7 @@ class Monitor extends Model
         return $this;
     }
 
-    protected static function alreadyExists(Monitor $monitor): bool
+    protected static function alreadyExists(self $monitor): bool
     {
         $query = static::where('url', $monitor->url);
 

--- a/src/Models/Traits/SupportsUptimeCheck.php
+++ b/src/Models/Traits/SupportsUptimeCheck.php
@@ -52,7 +52,9 @@ trait SupportsUptimeCheck
 
     public function uptimeRequestSucceeded(ResponseInterface $response)
     {
-        $uptimeResponseChecker = app(UptimeResponseChecker::class);
+        $uptimeResponseChecker = $this->uptime_check_response_checker
+            ? app($this->uptime_check_response_checker)
+            : app(UptimeResponseChecker::class);
 
         if (! $uptimeResponseChecker->isValidResponse($response, $this)) {
             $this->uptimeCheckFailed($uptimeResponseChecker->getFailureReason($response, $this));

--- a/tests/Integration/Commands/CheckUptimeCommandTest.php
+++ b/tests/Integration/Commands/CheckUptimeCommandTest.php
@@ -6,6 +6,7 @@ use Artisan;
 use Spatie\UptimeMonitor\Test\TestCase;
 use Spatie\UptimeMonitor\Models\Monitor;
 use Spatie\UptimeMonitor\Models\Enums\UptimeStatus;
+use Spatie\UptimeMonitor\Test\Integration\Helpers\ResponseCheckerFailureFake;
 
 class CheckUptimeCommandTest extends TestCase
 {
@@ -82,5 +83,21 @@ class CheckUptimeCommandTest extends TestCase
         $monitor = $monitor->fresh();
 
         $this->assertEquals(UptimeStatus::UP, $monitor->uptime_status);
+    }
+
+    /** @test */
+    public function it_can_use_a_custom_response_checker()
+    {
+        $monitor = factory(Monitor::class)->create([
+            'uptime_status' => UptimeStatus::NOT_YET_CHECKED,
+            'uptime_check_response_checker' => ResponseCheckerFailureFake::class,
+        ]);
+
+        Artisan::call('monitor:check-uptime');
+
+        $monitor = $monitor->fresh();
+
+        $this->assertEquals(UptimeStatus::DOWN, $monitor->uptime_status);
+        $this->assertEquals(ResponseCheckerFailureFake::FAILURE_REASON, $monitor->uptime_check_failure_reason);
     }
 }

--- a/tests/Integration/Helpers/ResponseCheckerFailureFake.php
+++ b/tests/Integration/Helpers/ResponseCheckerFailureFake.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\UptimeMonitor\Test\Integration\Helpers;
+
+use Psr\Http\Message\ResponseInterface;
+use Spatie\UptimeMonitor\Models\Monitor;
+use Spatie\UptimeMonitor\Helpers\UptimeResponseCheckers\UptimeResponseChecker;
+
+class ResponseCheckerFailureFake implements UptimeResponseChecker
+{
+    const FAILURE_REASON = 'FAKE_CHECK';
+
+    public function isValidResponse(ResponseInterface $response, Monitor $monitor) : bool
+    {
+        return false;
+    }
+
+    public function getFailureReason(ResponseInterface $response, Monitor $monitor) : string
+    {
+        return self::FAILURE_REASON;
+    }
+}


### PR DESCRIPTION
This PR adds the ability for each individual monitor to use a specific response checker rather than using the only that is globally applied.

This would provide much cleaner response checking for my particular use case.

## Usage

Just as you would manually update the monitor in the database, the fully qualified class name of the custom response checker would be entered into the `uptime_check_response_checker` column on the monitor record.