### PR TITLE
Add option to force run all monitors. Resolves #117.

### DIFF
--- a/src/Commands/CheckUptime.php
+++ b/src/Commands/CheckUptime.php
@@ -15,7 +15,7 @@ class CheckUptime extends BaseCommand
 
     public function handle()
     {
-        $monitors = $this->options('force') ? MonitorRepository::getEnabled() : MonitorRepository::getForUptimeCheck();
+        $monitors = $this->option('force') ? MonitorRepository::getEnabled() : MonitorRepository::getForUptimeCheck();
 
         if ($url = $this->option('url')) {
             $monitors = $monitors->filter(function (Monitor $monitor) use ($url) {

--- a/src/Commands/CheckUptime.php
+++ b/src/Commands/CheckUptime.php
@@ -7,14 +7,15 @@ use Spatie\UptimeMonitor\MonitorRepository;
 
 class CheckUptime extends BaseCommand
 {
-    protected $signature = 'monitor:check-uptime  
-                            {--url= : Only check these urls}';
+    protected $signature = 'monitor:check-uptime
+                            {--url= : Only check these urls}
+                            {--f|force : Force run all monitors }';
 
     protected $description = 'Check the uptime of all sites';
 
     public function handle()
     {
-        $monitors = MonitorRepository::getForUptimeCheck();
+        $monitors = $this->options('force') ? MonitorRepository::getEnabled() : MonitorRepository::getForUptimeCheck();
 
         if ($url = $this->option('url')) {
             $monitors = $monitors->filter(function (Monitor $monitor) use ($url) {


### PR DESCRIPTION
This PR adds ability to force run all monitors even ones which haven't reached their timeout yet, as asked in issue #117 