### PR TITLE
Use the TEST_SERVER_PORT environment variable in the MonitorFactory

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,3 +1,1 @@
 preset: laravel
-
-linting: true

--- a/tests/factories/MonitorFactory.php
+++ b/tests/factories/MonitorFactory.php
@@ -6,7 +6,7 @@ use Spatie\UptimeMonitor\Models\Enums\UptimeStatus;
 
 $factory->define(Monitor::class, function (Faker\Generator $faker) {
     return [
-        'url' => 'http://localhost:9000',
+        'url' => 'http://localhost:'.getenv('TEST_SERVER_PORT'),
         'uptime_status' => UptimeStatus::UP,
         'uptime_check_interval_in_minutes' => config('uptime-monitor.uptime_check.run_interval_in_minutes'),
         'uptime_status_last_change_date' => Carbon::now(),


### PR DESCRIPTION
Heya :wave:,

For some reason I was unable to run the PHP webserver used for testing on port 9000 (port was already taken ). After changing the value I discovered that some tests are still stuck because they tried to communicate to the old `9000` port. This PR should create consistency in the location of the testserver and the generated monitor URL's :smile:.

Thanks for the awesome package! :tada: 