### PR TITLE
Update grahamcampbell guzzle factory

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,3 +1,1 @@
 preset: laravel
-
-linting: true

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "graham-campbell/guzzle-factory": "^2.1",
+        "graham-campbell/guzzle-factory": "^3.0",
         "guzzlehttp/guzzle": "^6.3",
         "illuminate/console": "~5.5.0|~5.6.0",
         "illuminate/database": "~5.5.0|~5.6.0",


### PR DESCRIPTION
Hey again, :wave: 

I wanted to use this package in a local project but the composer installation is blocked due to version constraints of in GrahamCampbell/Guzzle-Factory. This PR should fix that. 

### What has been done:
 - bumped graham-campbell/guzzle-factory to v3, since the API changes are minimal and did not affect the usage of the bundle I think we good :+1: 

### Notes:
- Stacked upon #143  because I needed the changes in .styleci