### PR TITLE
Add ability to track response time

### DIFF
--- a/database/migrations/create_monitors_table.php.stub
+++ b/database/migrations/create_monitors_table.php.stub
@@ -24,6 +24,7 @@ class CreateMonitorsTable extends Migration
             $table->string('uptime_status')->default(UptimeStatus::NOT_YET_CHECKED);
             $table->string('uptime_check_failure_reason')->default('');
             $table->integer('uptime_check_times_failed_in_a_row')->default(0);
+            $table->integer('uptime_check_response_time')->nullable();
             $table->timestamp('uptime_status_last_change_date')->nullable();
             $table->timestamp('uptime_last_check_date')->nullable();
             $table->timestamp('uptime_check_failed_event_fired_on_date')->nullable();

--- a/src/MonitorCollection.php
+++ b/src/MonitorCollection.php
@@ -3,6 +3,7 @@
 namespace Spatie\UptimeMonitor;
 
 use Generator;
+use GuzzleHttp\TransferStats;
 use Illuminate\Support\Collection;
 use GuzzleHttp\Promise\EachPromise;
 use Psr\Http\Message\ResponseInterface;
@@ -54,6 +55,9 @@ class MonitorCollection extends Collection
                     'connect_timeout' => config('uptime-monitor.uptime_check.timeout_per_site'),
                     'headers' => $this->promiseHeaders($monitor),
                     'body' => $monitor->uptime_check_payload,
+                    'on_stats' => function (TransferStats $stats) use ($monitor) {
+                        $monitor->uptime_check_response_time = $stats->getTransferTime();
+                    },
                 ])
             );
 


### PR DESCRIPTION
This PR adds `uptime_check_response_time` to the `Monitor` model. 

It is left up to the consumer to decide if and how this information should be used. One could listen for the events and then add the response times to redis, a file cache, or the database.