### PR TITLE
Fix issues in CheckCertificatesTest

### DIFF
--- a/tests/Integration/Commands/CheckCertificatesTest.php
+++ b/tests/Integration/Commands/CheckCertificatesTest.php
@@ -45,11 +45,11 @@ class CheckCertificatesTest extends TestCase
     {
         $monitor1 = factory(Monitor::class)->create(['certificate_check_enabled' => false]);
         $monitor2 = factory(Monitor::class)->create([
-            'url' => 'https://www.google.com',
+            'url' => 'https://google.com',
             'certificate_check_enabled' => true,
         ]);
         $monitor3 = factory(Monitor::class)->create([
-            'url' => 'https://www.bing.com',
+            'url' => 'https://bing.com',
             'certificate_check_enabled' => true,
         ]);
 

--- a/tests/Integration/Commands/CheckCertificatesTest.php
+++ b/tests/Integration/Commands/CheckCertificatesTest.php
@@ -23,6 +23,7 @@ class CheckCertificatesTest extends TestCase
         $this->seeInConsoleOutput("Checking certificate of {$monitor->url}");
     }
 
+    /** @test */
     public function it_can_check_the_certificate_for_a_specific_monitor()
     {
         $monitor1 = factory(Monitor::class)->create(['certificate_check_enabled' => true]);
@@ -31,28 +32,34 @@ class CheckCertificatesTest extends TestCase
             'certificate_check_enabled' => true,
         ]);
 
-        Artisan::call('monitor:check-uptime', ['--url' => $monitor1->url]);
+        Artisan::call('monitor:check-certificate', ['--url' => $monitor1->url]);
 
-        $this->seeInConsoleOutput("Checking certificate of {$monitor1->url}");
-        $this->dontSeeInConsoleOutput("Checking certificate of {$monitor2->url}");
+        $output = Artisan::output();
+
+        $this->assertContains("Checking certificate of {$monitor1->url}", $output);
+        $this->assertNotContains("Checking certificate of {$monitor2->url}", $output);
     }
 
+    /** @test */
     public function it_can_check_the_certificates_for_a_specific_set_of_monitors()
     {
-        $monitor1 = factory(Monitor::class)->create(['certificate_check_enabled' => true]);
+        $monitor1 = factory(Monitor::class)->create(['certificate_check_enabled' => false]);
         $monitor2 = factory(Monitor::class)->create([
-            'url' => 'https://google.com',
+            'url' => 'https://www.google.com',
             'certificate_check_enabled' => true,
         ]);
         $monitor3 = factory(Monitor::class)->create([
-            'url' => 'https://bing.com',
+            'url' => 'https://www.bing.com',
             'certificate_check_enabled' => true,
         ]);
 
-        Artisan::call('monitor:check-uptime', ['--url' => $monitor1->url.','.$monitor2->url]);
+        Artisan::call('monitor:check-certificate', ['--url' => $monitor2->url.','.$monitor3->url]);
 
-        $this->seeInConsoleOutput("Checking certificate of {$monitor1->url}");
-        $this->seeInConsoleOutput("Checking certificate of {$monitor2->url}");
-        $this->dontSeeInConsoleOutput("Checking certificate of {$monitor3->url}");
+        $output = Artisan::output();
+
+        $this->assertNotContains("Checking certificate of {$monitor1->url}", $output);
+        $this->assertContains("Checking certificate of {$monitor2->url}", $output);
+        $this->assertContains("Checking certificate of {$monitor3->url}", $output);
+        
     }
 }


### PR DESCRIPTION
Fix three issues with the tests in CheckCertificatesTest

- @test annotation was missing from it_can_check_the_certificate_for_a_specific_monitor() and it_can_check_the_certificates_for_a_specific_set_of_monitors()
- these tests were then calling monitor:check-uptime
- subsequent calls to seeInConsoleOutput/dontSeeInConsoleOutput were checking against an empty string
