### PR TITLE
Add flag to allow for untrimed URL input

### DIFF
--- a/src/Commands/CreateMonitor.php
+++ b/src/Commands/CreateMonitor.php
@@ -14,7 +14,7 @@ class CreateMonitor extends BaseCommand
     public function handle()
     {
         $url = Url::fromString($this->argument('url'));
-        $noTrimUrl = $this->option('queue');
+        $noTrimUrl = $this->option('no-trim');
 
         if (! in_array($url->getScheme(), ['http', 'https'])) {
             if ($scheme = $this->choice("Which protocol needs to be used for checking `{$url}`?", [1 => 'https', 2 => 'http'], 1)) {

--- a/src/Commands/CreateMonitor.php
+++ b/src/Commands/CreateMonitor.php
@@ -7,13 +7,14 @@ use Spatie\UptimeMonitor\Models\Monitor;
 
 class CreateMonitor extends BaseCommand
 {
-    protected $signature = 'monitor:create {url}';
+    protected $signature = 'monitor:create {url} {--N|no-trim : Don\'t trim the trailing slash on URL input.}';
 
     protected $description = 'Create a monitor';
 
     public function handle()
     {
         $url = Url::fromString($this->argument('url'));
+        $noTrimUrl = $this->option('queue');
 
         if (! in_array($url->getScheme(), ['http', 'https'])) {
             if ($scheme = $this->choice("Which protocol needs to be used for checking `{$url}`?", [1 => 'https', 2 => 'http'], 1)) {
@@ -26,7 +27,7 @@ class CreateMonitor extends BaseCommand
         }
 
         $monitor = Monitor::create([
-            'url' => trim($url, '/'),
+            'url' => $noTrimUrl ? $url : trim($url, '/'),
             'look_for_string' => $lookForString ?? '',
             'uptime_check_method' => isset($lookForString) ? 'get' : 'head',
             'certificate_check_enabled' => $url->getScheme() === 'https',


### PR DESCRIPTION
This change should, in theory, allow for a users URL input to not be trimmed of trailing slashes.

The upside is that this allows the tool to be useful for monitoring sites with Canonical URLs that include the trailing slash. While it may not be the majority of cases - some servers/sites may be configured to redirect requests to the Canonical URL. So this change should help users in those instances.

The only downside I can think of currently is that a user could now redundantly monitor the same page/site twice. This would be the result if, for example, they configured a url with and without the flag given. However this is something that would be hard to do accidentally - so IMO the risk here is pretty minimal.

Related to #107.