### PR TITLE
Add the ability to pass customizations to Guzzle

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,13 @@ return [
         /*
          * When reaching out to the sites these headers will be added.
          */
-        'additional_headers' => []
+        'additional_headers' => [],
+        
+        /*
+         * Options passed to Guzzle allowing you to customize how requests are 
+         * made.
+         */
+        'guzzle_options' => [],
     ],
 
     'certificate_check' => [

--- a/config/uptime-monitor.php
+++ b/config/uptime-monitor.php
@@ -105,6 +105,12 @@ return [
          * When reaching out to the sites these headers will be added.
          */
         'additional_headers' => [],
+
+        /*
+         * Options passed to Guzzle allowing you to customize how requests are
+         * made.
+         */
+        'guzzle_options' => [],
     ],
 
     'certificate_check' => [

--- a/src/MonitorCollection.php
+++ b/src/MonitorCollection.php
@@ -40,7 +40,7 @@ class MonitorCollection extends Collection
     protected function getPromises(): Generator
     {
         $client = GuzzleFactory::make(
-            [],
+            config('uptime-monitor.uptime-check.guzzle_options', []),
             config('uptime-monitor.uptime-check.retry_connection_after_milliseconds', 100)
         );
 


### PR DESCRIPTION
I think it would be nice to allow some customizations around how Guzzle is configured. Based on my use case being able to set `'http_errors' => false` would be helpful.