### PR TITLE
Fix issue migration with MySQL 5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to `laravel-uptime-monitor` will be documented in this file
 
 ## Unreleased
+### Fixed
+- Fixed issue with migrations stub
 
 ## 3.4.0 - 2019-03-03
 ### Changed

--- a/database/migrations/create_monitors_table.php.stub
+++ b/database/migrations/create_monitors_table.php.stub
@@ -22,7 +22,7 @@ class CreateMonitorsTable extends Migration
             $table->string('look_for_string')->default('');
             $table->string('uptime_check_interval_in_minutes')->default(5);
             $table->string('uptime_status')->default(UptimeStatus::NOT_YET_CHECKED);
-            $table->text('uptime_check_failure_reason')->default('');
+            $table->text('uptime_check_failure_reason')->nullable();
             $table->integer('uptime_check_times_failed_in_a_row')->default(0);
             $table->timestamp('uptime_status_last_change_date')->nullable();
             $table->timestamp('uptime_last_check_date')->nullable();


### PR DESCRIPTION
## Description
Fixes an issue with MySQL 5.7 migrations where `TEXT` column type can not have a default value. This PR changes it to `nullable` instead.

Resolves #169 