### PR TITLE
Add `raw_url` attribute to serialization

### DIFF
--- a/src/Models/Monitor.php
+++ b/src/Models/Monitor.php
@@ -19,6 +19,8 @@ class Monitor extends Model
 
     protected $guarded = [];
 
+    protected $appends = ['raw_url'];
+
     protected $dates = [
         'uptime_last_check_date',
         'uptime_status_last_change_date',
@@ -60,6 +62,14 @@ class Monitor extends Model
         }
 
         return Url::fromString($this->attributes['url']);
+    }
+
+    /**
+     * @return string
+     */
+    public function getRawUrlAttribute()
+    {
+        return (string) $this->url;
     }
 
     public static function boot()

--- a/tests/Integration/Models/MonitorTest.php
+++ b/tests/Integration/Models/MonitorTest.php
@@ -63,9 +63,9 @@ class MonitorTest extends TestCase
     }
 
     /** @test */
-    function raw_url_is_appended_during_serialization()
+    public function raw_url_is_appended_during_serialization()
     {
-       $this->assertEquals(
+        $this->assertEquals(
             'http://mysite.com',
             $this->monitor->toArray()['raw_url']
         );

--- a/tests/Integration/Models/MonitorTest.php
+++ b/tests/Integration/Models/MonitorTest.php
@@ -61,4 +61,13 @@ class MonitorTest extends TestCase
         //it will not enable the certificate check for a non-https site.
         $this->assertFalse($this->monitor->certificate_check_enabled);
     }
+
+    /** @test */
+    function raw_url_is_appended_during_serialization()
+    {
+       $this->assertEquals(
+            'http://mysite.com',
+            $this->monitor->toArray()['raw_url']
+        );
+    }
 }


### PR DESCRIPTION
## Description
Adds a `raw_url` attribute to the monitor so the URL is accessible as a string during serialization.

Resolves #173 