### PR TITLE
Removing rougue spaces on getting started page

### DIFF
--- a/docs/monitoring-uptime/getting-started.md
+++ b/docs/monitoring-uptime/getting-started.md
@@ -21,13 +21,13 @@ Read the [high level overview section](https://docs.spatie.be/laravel-uptime-mon
 
 Instead of using the `monitor:create` command you may also manually create a row in the `monitors` table. Here's [a description of all the fields in that table](https://docs.spatie.be/laravel-uptime-monitor/v3/advanced-usage/manually-modifying-monitors).
  
- ## Removing a monitor
+## Removing a monitor
  
- You can remove a monitor by running `monitor:delete`. Here's how to delete the monitor for `https://laravel.com`:
+You can remove a monitor by running `monitor:delete`. Here's how to delete the monitor for `https://laravel.com`:
  
- ```php
- php artisan monitor:delete https://laravel.com
- ```
+```php
+php artisan monitor:delete https://laravel.com
+```
  
 This will remove the monitor for laravel.com from the database. Want to delete multiple monitors at once? Just pass all the urls as comma-separated list.
 


### PR DESCRIPTION
There were some rogue spaces at the start of the lines in the 'Removing a monitor' that were causing the markdown to not render correctly.