### PR TITLE
Use the namespaced class for the Event facade

### DIFF
--- a/tests/Integration/Events/CertificateCheckFailedTest.php
+++ b/tests/Integration/Events/CertificateCheckFailedTest.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\UptimeMonitor\Test\Integration\Events;
 
-use Event;
+use Illuminate\Support\Facades\Event;
 use Spatie\UptimeMonitor\Events\CertificateCheckFailed;
 use Spatie\UptimeMonitor\Models\Monitor;
 use Spatie\UptimeMonitor\Test\TestCase;

--- a/tests/Integration/Events/CertificateCheckSucceededTest.php
+++ b/tests/Integration/Events/CertificateCheckSucceededTest.php
@@ -3,7 +3,7 @@
 namespace Spatie\UptimeMonitor\Test\Integration\Events;
 
 use Carbon\Carbon;
-use Event;
+use Illuminate\Support\Facades\Event;
 use Spatie\UptimeMonitor\Events\CertificateCheckSucceeded;
 use Spatie\UptimeMonitor\Models\Monitor;
 use Spatie\UptimeMonitor\Test\TestCase;

--- a/tests/Integration/Events/UptimeCheckFailedTest.php
+++ b/tests/Integration/Events/UptimeCheckFailedTest.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\UptimeMonitor\Test\Integration\Events;
 
-use Event;
+use Illuminate\Support\Facades\Event;
 use Spatie\UptimeMonitor\Events\UptimeCheckFailed;
 use Spatie\UptimeMonitor\Events\UptimeCheckRecovered;
 use Spatie\UptimeMonitor\Events\UptimeCheckSucceeded;

--- a/tests/Integration/Events/UptimeCheckRecoveredTest.php
+++ b/tests/Integration/Events/UptimeCheckRecoveredTest.php
@@ -3,7 +3,7 @@
 namespace Spatie\UptimeMonitor\Test\Integration\Events;
 
 use Carbon\Carbon;
-use Event;
+use Illuminate\Support\Facades\Event;
 use Spatie\UptimeMonitor\Events\UptimeCheckRecovered;
 use Spatie\UptimeMonitor\Models\Monitor;
 use Spatie\UptimeMonitor\MonitorRepository;

--- a/tests/Integration/Events/UptimeCheckSucceededTest.php
+++ b/tests/Integration/Events/UptimeCheckSucceededTest.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\UptimeMonitor\Test\Integration\Events;
 
-use Event;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
 use Spatie\UptimeMonitor\Events\UptimeCheckSucceeded;
 use Spatie\UptimeMonitor\Models\Monitor;
 use Spatie\UptimeMonitor\MonitorRepository;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,9 +4,9 @@ namespace Spatie\UptimeMonitor\Test;
 
 use Artisan;
 use Carbon\Carbon;
-use Event;
 use GuzzleHttp\Client;
 use Illuminate\Notifications\SlackChannelServiceProvider;
+use Illuminate\Support\Facades\Event;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Spatie\UptimeMonitor\UptimeMonitorServiceProvider;
 


### PR DESCRIPTION
If you have PHP's `ext/event` installed, it provides a class named `Event` which collides with the use of Laravel's `Event` facade when used as a global alias.  To prevent the class collision, the namespaced class is used instead.