### PR TITLE
Change type of exception handled in rejected promise

### DIFF
--- a/src/MonitorCollection.php
+++ b/src/MonitorCollection.php
@@ -4,7 +4,7 @@ namespace Spatie\UptimeMonitor;
 
 use Generator;
 use GrahamCampbell\GuzzleFactory\GuzzleFactory;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Promise\EachPromise;
 use Illuminate\Support\Collection;
 use Psr\Http\Message\ResponseInterface;
@@ -27,7 +27,7 @@ class MonitorCollection extends Collection
                 $monitor->uptimeRequestSucceeded($response);
             },
 
-            'rejected' => function (RequestException $exception, $index) {
+            'rejected' => function (TransferException $exception, $index) {
                 $monitor = $this->getMonitorAtIndex($index);
 
                 ConsoleOutput::error("Could not reach {$monitor->url} error: `{$exception->getMessage()}`");


### PR DESCRIPTION
As noted in Guzzle's [upgrade document](https://github.com/guzzle/guzzle/blob/master/UPGRADING.md), in Guzzle 7 `GuzzleHttp\Exception\ConnectException` now extends from `GuzzleHttp\Exception\TransferException` instead of `GuzzleHttp\Exception\RequestException`, which now causes a fatal error in the rejected callback because ConnectException is no longer an instance of RequestException.  This change allows for ConnectException to be handled when using Guzzle 7 while remaining B/C with Guzzle 6.