### PR TITLE
Option to enable/disable all monitors

### DIFF
--- a/src/Commands/DisableMonitor.php
+++ b/src/Commands/DisableMonitor.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\UptimeMonitor\Commands;
 
+use Spatie\UptimeMonitor\Models\Monitor;
 use Spatie\UptimeMonitor\MonitorRepository;
 
 class DisableMonitor extends BaseCommand
@@ -12,14 +13,24 @@ class DisableMonitor extends BaseCommand
 
     public function handle()
     {
-        foreach (explode(',', $this->argument('url')) as $url) {
+        $urls = null;
+
+        if ($this->argument('url') == 'all') {
+            $urls = Monitor::get()->pluck('url');
+        }
+
+        if (is_null($urls)) {
+            $urls = explode(',', $this->argument('url'));
+        }
+
+        foreach ($urls as $url) {
             $this->disableMonitor(trim($url));
         }
     }
 
     protected function disableMonitor(string $url)
     {
-        if (! $monitor = MonitorRepository::findByUrl($url)) {
+        if (!$monitor = MonitorRepository::findByUrl($url)) {
             $this->error("There is no monitor configured for url `{$url}`.");
 
             return;

--- a/src/Commands/EnableMonitor.php
+++ b/src/Commands/EnableMonitor.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\UptimeMonitor\Commands;
 
+use Spatie\UptimeMonitor\Models\Monitor;
 use Spatie\UptimeMonitor\MonitorRepository;
 
 class EnableMonitor extends BaseCommand
@@ -12,14 +13,24 @@ class EnableMonitor extends BaseCommand
 
     public function handle()
     {
-        foreach (explode(',', $this->argument('url')) as $url) {
+        $urls = null;
+
+        if ($this->argument('url') == 'all') {
+            $urls = Monitor::get()->pluck('url');
+        }
+
+        if (is_null($urls)) {
+            $urls = explode(',', $this->argument('url'));
+        }
+
+        foreach ($urls as $url) {
             $this->enableMonitor(trim($url));
         }
     }
 
     protected function enableMonitor(string $url)
     {
-        if (! $monitor = MonitorRepository::findByUrl($url)) {
+        if (!$monitor = MonitorRepository::findByUrl($url)) {
             $this->error("There is no monitor configured for url `{$url}`.");
 
             return;


### PR DESCRIPTION
Testing the waters for this feature to completely disable/enable monitoring on all sites (without removing the cronjob).

The other day Cloudflare had some major issues in Frankfurt and I am monitoring 50 sites at this location. After getting flooded with emails I would like to temporarily disable the monitoring since I know the issue is not a site level. 

Another scenario is if I have to take the server down for updates, then I also get flooded by emails. 

In a dream scenario, I would like to have a snooze-feature that temporarily disables all monitoring for X hours while the dust settles, but I don't know the interest in building such a feature.