### PR TITLE
PHP 8.0 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [7.4]
+                php: [7.4, 8.0]
                 laravel: [8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^7.4",
+        "php": "^7.4|^8.0",
         "graham-campbell/guzzle-factory": "^4.0",
         "guzzlehttp/guzzle": "^7.0",
         "laravel/framework": "^8.7",
@@ -26,8 +26,8 @@
         "spatie/url": "^1.0.1"
     },
     "require-dev": {
-        "laravel/legacy-factories": "^1.0.5",
-        "mockery/mockery": "^1.0",
+        "laravel/legacy-factories": "^1.1",
+        "mockery/mockery": "^1.4",
         "orchestra/testbench": "^6.0",
         "phpunit/phpunit": "^9.0"
     },

--- a/tests/Server.php
+++ b/tests/Server.php
@@ -66,7 +66,7 @@ class Server
 
     public static function getServerUrl(string $endPoint = ''): string
     {
-        return sprintf('localhost:%s/%s', getenv('TEST_SERVER_PORT'), $endPoint);
+        return rtrim(sprintf('localhost:%s/%s', getenv('TEST_SERVER_PORT'), $endPoint), '/');
     }
 
     public static function serverHasBooted(): bool

--- a/tests/server/composer.json
+++ b/tests/server/composer.json
@@ -5,8 +5,8 @@
     "license": "MIT",
     "type": "project",
     "require": {
-        "php": ">=5.6.4",
-        "laravel/lumen-framework": "5.4.*"
+        "php": ">=7.4",
+        "laravel/lumen-framework": "^8.2"
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/tests/server/public/index.php
+++ b/tests/server/public/index.php
@@ -10,7 +10,7 @@ $app = new Laravel\Lumen\Application(
 
 $storagePath = __DIR__.'/../storage/server-status-code.json';
 
-$app->get('/', function () use ($storagePath) {
+$app->router->get('/', function () use ($storagePath) {
     if (! file_exists($storagePath)) {
         return response('Site is up', 200);
     }
@@ -24,13 +24,13 @@ $app->get('/', function () use ($storagePath) {
     return response($response['body'], $response['statusCode']);
 });
 
-$app->post('/setServerResponse', function (Request $request) use ($storagePath) {
+$app->router->post('/setServerResponse', function (Request $request) use ($storagePath) {
     $response = json_encode($request->all(), true);
 
     file_put_contents($storagePath, $response);
 });
 
-$app->post('/testPost', function (Request $request) {
+$app->router->post('/testPost', function (Request $request) {
     if ($request->get('foo') !== 'bar' && $request->header('Content-Type') !== 'application/json') {
         return response(null, 500);
     }
@@ -38,7 +38,7 @@ $app->post('/testPost', function (Request $request) {
     return response(null, 200);
 });
 
-$app->get('booted', function () {
+$app->router->get('booted', function () {
     return 'app has booted';
 });
 


### PR DESCRIPTION
Updated php requirements and fixed deprecations to allow for php 8

- upgraded dependencies for package and test Server
- removing trailing slash in getServerUrl to fix server boot
- updated server routing logic to accommodate lumen 5.5 router changes
- added php 8.0 to workflow