### PR TITLE
Use CarbonInterface instead of Carbon on type hints

### DIFF
--- a/src/Exceptions/InvalidPeriod.php
+++ b/src/Exceptions/InvalidPeriod.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\UptimeMonitor\Exceptions;
 
-use Carbon\Carbon;
 use Carbon\CarbonInterface;
 use Exception;
 

--- a/src/Exceptions/InvalidPeriod.php
+++ b/src/Exceptions/InvalidPeriod.php
@@ -3,11 +3,12 @@
 namespace Spatie\UptimeMonitor\Exceptions;
 
 use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Exception;
 
 class InvalidPeriod extends Exception
 {
-    public static function startDateMustComeBeforeEndDate(Carbon $startDateTime, Carbon $endDateTime): self
+    public static function startDateMustComeBeforeEndDate(CarbonInterface $startDateTime, CarbonInterface $endDateTime): self
     {
         return new static("The given startDateTime `{$startDateTime->toIso8601String()}` is not before `{$endDateTime->toIso8601String()}`");
     }

--- a/src/Helpers/Period.php
+++ b/src/Helpers/Period.php
@@ -2,15 +2,14 @@
 
 namespace Spatie\UptimeMonitor\Helpers;
 
-use Carbon\Carbon;
 use Carbon\CarbonInterface;
 use Spatie\UptimeMonitor\Exceptions\InvalidPeriod;
 
 class Period
 {
-    public Carbon $startDateTime;
+    public CarbonInterface $startDateTime;
 
-    public Carbon $endDateTime;
+    public CarbonInterface $endDateTime;
 
     public function __construct(CarbonInterface $startDateTime, CarbonInterface $endDateTime)
     {

--- a/src/Helpers/Period.php
+++ b/src/Helpers/Period.php
@@ -3,6 +3,7 @@
 namespace Spatie\UptimeMonitor\Helpers;
 
 use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Spatie\UptimeMonitor\Exceptions\InvalidPeriod;
 
 class Period
@@ -11,7 +12,7 @@ class Period
 
     public Carbon $endDateTime;
 
-    public function __construct(Carbon $startDateTime, Carbon $endDateTime)
+    public function __construct(CarbonInterface $startDateTime, CarbonInterface $endDateTime)
     {
         if ($startDateTime->gt($endDateTime)) {
             throw  InvalidPeriod::startDateMustComeBeforeEndDate($startDateTime, $endDateTime);


### PR DESCRIPTION
If you have this in your service provider:

```
 Date::use(CarbonImmutable::class);
 ```

Laravel will not use an instance of `Carbon` but `CarbonImmutable` whenever resolving it from the container.. however it is better to type hint `CarbonInterface` everywhere 
