### PR TITLE
Fix documentation images

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -5,9 +5,9 @@ weight: 1
 
 Laravel-uptime-monitor is a laravel package that provides a powerful, easy to configure uptime monitor. It will notify you when your site is down (and when it comes back up). You can also be notified a few days before an SSL certificate on one of your sites expires. Under the hood, the package leverages Laravel native notifications, so it's easy to use Slack, Telegram or your preferred notification provider.
 
-<img src="../images/monitor-failed.jpg" class="screenshot -slack" /><br />
-<img src="../images/monitor-recovered.jpg" class="screenshot -slack" /><br />
-<img src="../images/ssl-expiring-soon.jpg" class="screenshot -slack" /><br />
+<img src="./images/monitor-failed.jpg" class="screenshot -slack" /><br />
+<img src="./images/monitor-recovered.jpg" class="screenshot -slack" /><br />
+<img src="./images/ssl-expiring-soon.jpg" class="screenshot -slack" /><br />
 
 If you' not familiar with Laravel, but still want to use this uptime monitor, take a look at the [uptime-monitor-app](https://github.com/spatie/uptime-monitor-app) repo which contains a stand alone version of this package.
 

--- a/docs/monitoring-ssl-certificates/notifications.md
+++ b/docs/monitoring-ssl-certificates/notifications.md
@@ -13,7 +13,7 @@ This notification will be sent when the `Spatie\UptimeMonitor\Events\Certificate
 
 This is how the notification looks in Slack.
 
-<img src="../../images/ssl-certificate-failed.jpg" class="screenshot -slack" />
+<img src="./../images/ssl-certificate-failed.jpg" class="screenshot -slack" />
 
 ## CertificateExpiresSoon
 
@@ -23,7 +23,7 @@ This notification will be sent when the `Spatie\UptimeMonitor\Events\Certificate
 
 This is how the notification looks in Slack.
 
-<img src="../../images/ssl-expiring-soon.jpg" class="screenshot -slack" />
+<img src="./../images/ssl-expiring-soon.jpg" class="screenshot -slack" />
 
 ## CertificateCheckSucceeded
 

--- a/docs/monitoring-uptime/notifications.md
+++ b/docs/monitoring-uptime/notifications.md
@@ -13,7 +13,7 @@ This notification will be sent when the `Spatie\UptimeMonitor\Events\UptimeCheck
 
 This is how the notification looks in Slack.
 
-<img src="../../images/monitor-failed.jpg" class="screenshot -slack" />
+<img src="./../images/monitor-failed.jpg" class="screenshot -slack" />
 
 ## UptimeCheckRecovered
 
@@ -23,7 +23,7 @@ This notification will be sent when the `Spatie\UptimeMonitor\Events\UptimeCheck
 
 This is how the notification looks in Slack.
 
-<img src="../../images/monitor-recovered.jpg" class="screenshot -slack" />
+<img src="./../images/monitor-recovered.jpg" class="screenshot -slack" />
 
 ## UptimeCheckSucceeded
 


### PR DESCRIPTION
Multiple image paths were incorrect like here: https://spatie.be/docs/laravel-uptime-monitor/v3/introduction .