### PR TITLE
Modify composer requires to illuminate/* alternatives

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,25 @@
     "require": {
         "php": "^7.4|^8.0",
         "ext-intl": "*",
+        "ext-json": "*",
         "graham-campbell/guzzle-factory": "^5.0",
         "guzzlehttp/guzzle": "^7.4",
-        "laravel/framework": "^8.73|^9.0",
-        "laravel/slack-notification-channel": "^2.3",
+        "illuminate/cache": "^8.73|^9.0",
+        "illuminate/config": "^8.73|^9.0",
+        "illuminate/console": "^8.73|^9.0",
+        "illuminate/container": "^8.73|^9.0",
+        "illuminate/contracts": "^8.73|^9.0",
+        "illuminate/events": "^8.73|^9.0",
+        "illuminate/filesystem": "^8.73|^9.0",
+        "illuminate/notifications": "^8.73|^9.0",
+        "illuminate/support": "^8.73|^9.0",
+        "laravel/slack-notification-channel": "^2.4",
         "spatie/ssl-certificate": "^1.22|^2.1.2",
         "spatie/url": "^1.0.1"
     },
     "require-dev": {
         "mockery/mockery": "^1.4",
+        "illuminate/testing": "^8.73|^9.0",
         "orchestra/testbench": "^6.23|^7.0",
         "phpunit/phpunit": "^9.5"
     },


### PR DESCRIPTION
Hey there, I've finally had time to come back to an issue I reported a while ago which was auto-closed. The original intent was getting this package working within Laravel-Zero.

Original report: https://github.com/spatie/laravel-uptime-monitor/issues/222