### PR TITLE
Add dynamic resend failed notification delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,20 @@ return [
 
         /*
          * To keep reminding you that a site is down, notifications
-         * will be resent every given number of minutes.
+         * will be resent every given number of minutes. Value can 
+         * be either an integer to send at a fixed interval, or 
+         * an array where key is minutes since down and value
+         * is minutes between notifications
          */
         'resend_uptime_check_failed_notification_every_minutes' => 60,
+
+        // 'resend_uptime_check_failed_notification_every_minutes' => [
+        //     0 => 15, // Start by notifying every 15 minutes
+        //     6* 60 => 30, // After 6 hours notify every 30 minutes
+        //     24 * 60 => 60, // After 24 hours notify every 60 minutes
+        //     3 * 24 * 60 => 4 * 60, // After 3 days notify every 4 hours
+        //     7 * 24 * 60 => 24 * 60 // After 7 days notify every 24 hours
+        // ],
 
         'mail' => [
             'to' => ['your@email.com'],

--- a/config/uptime-monitor.php
+++ b/config/uptime-monitor.php
@@ -26,9 +26,20 @@ return [
 
         /*
          * To keep reminding you that a site is down, notifications
-         * will be resent every given number of minutes.
+         * will be resent every given number of minutes. Value can
+         * be either an integer to send at a fixed interval, or
+         * an array where key is minutes since down and value
+         * is minutes between notifications
          */
         'resend_uptime_check_failed_notification_every_minutes' => 60,
+
+        // 'resend_uptime_check_failed_notification_every_minutes' => [
+        //     0 => 15, // Start by notifying every 15 minutes
+        //     6* 60 => 30, // After 6 hours notify every 30 minutes
+        //     24 * 60 => 60, // After 24 hours notify every 60 minutes
+        //     3 * 24 * 60 => 4 * 60, // After 3 days notify every 4 hours
+        //     7 * 24 * 60 => 24 * 60 // After 7 days notify every 24 hours
+        // ],
 
         'mail' => [
             'to' => ['your@email.com'],

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -52,9 +52,20 @@ return [
 
         /*
          * To keep reminding you that a site is down, notifications
-         * will be resent every given number of minutes.
+         * will be resent every given number of minutes. Value can 
+         * be either an integer to send at a fixed interval, or 
+         * an array where key is minutes since down and value
+         * is minutes between notifications
          */
         'resend_uptime_check_failed_notification_every_minutes' => 60,
+
+        // 'resend_uptime_check_failed_notification_every_minutes' => [
+        //     0 => 15, // Start by notifying every 15 minutes
+        //     6* 60 => 30, // After 6 hours notify every 30 minutes
+        //     24 * 60 => 60, // After 24 hours notify every 60 minutes
+        //     3 * 24 * 60 => 4 * 60, // After 3 days notify every 4 hours
+        //     7 * 24 * 60 => 24 * 60 // After 7 days notify every 24 hours
+        // ],
 
         'mail' => [
             'to' => ['your@email.com'],

--- a/src/Models/Traits/SupportsUptimeCheck.php
+++ b/src/Models/Traits/SupportsUptimeCheck.php
@@ -124,11 +124,19 @@ trait SupportsUptimeCheck
             return false;
         }
 
-        if (config('uptime-monitor.notifications.resend_uptime_check_failed_notification_every_minutes') === 0) {
+        if (is_array(config('uptime-monitor.notifications.resend_uptime_check_failed_notification_every_minutes'))) {
+            $resend_failed_notification_delay = collect(config('uptime-monitor.notifications.resend_uptime_check_failed_notification_every_minutes'))->sortKeysDesc()->firstWhere(function ($value, $key) {
+                return $key < $this->uptime_status_last_change_date->diffInMinutes() || $this->uptime_status_last_change_date->diffInMinutes() == 0;
+            });
+        } else {
+            $resend_failed_notification_delay = config('uptime-monitor.notifications.resend_uptime_check_failed_notification_every_minutes');
+        }
+
+        if ($resend_failed_notification_delay === 0) {
             return false;
         }
 
-        if ($this->uptime_check_failed_event_fired_on_date->diffInMinutes() >= config('uptime-monitor.notifications.resend_uptime_check_failed_notification_every_minutes')) {
+        if ($this->uptime_check_failed_event_fired_on_date->diffInMinutes() >= $resend_failed_notification_delay) {
             return true;
         }
 


### PR DESCRIPTION
This adds an option to vary the delay between failed notifications by defining an array in the config instead of an integer. Delay varies by the time since the website went down, where you defire an array where key is minutes since breakdown and value is the delay.
