### PR TITLE
Add support for Laravel 11

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,21 +9,17 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [8.1, 8.0]
-                laravel: [9.*, 8.*, 10.*]
+                php: [8.1, 8.2, 8.3]
+                laravel: [10.*, 11.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
                     -   laravel: 10.*
                         testbench: 8.*
-                    -   laravel: 9.*
-                        testbench: 7.*
-                    -   laravel: 8.*
-                        testbench: ^6.23
+                    -   laravel: 11.*
+                        testbench: 9.*
                 exclude:
-                    -   laravel: 10.*
-                        php: 8.0
-                    -   laravel: 9.*
-                        php: 7.4
+                    -   laravel: 11.*
+                        php: 8.1
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -16,29 +16,29 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-intl": "*",
         "ext-json": "*",
-        "graham-campbell/guzzle-factory": "^5.0",
+        "graham-campbell/guzzle-factory": "^5.0|^7.0",
         "guzzlehttp/guzzle": "^7.4|^7.2",
-        "illuminate/cache": "^8.73|^9.0|^10.0",
-        "illuminate/config": "^8.73|^9.0|^10.0",
-        "illuminate/console": "^8.73|^9.0|^10.0",
-        "illuminate/container": "^8.73|^9.0|^10.0",
-        "illuminate/contracts": "^8.73|^9.0|^10.0",
-        "illuminate/events": "^8.73|^9.0|^10.0",
-        "illuminate/filesystem": "^8.73|^9.0|^10.0",
-        "illuminate/notifications": "^8.73|^9.0|^10.0",
-        "illuminate/support": "^8.73|^9.0|^10.0",
-        "laravel/slack-notification-channel": "^2.4",
+        "illuminate/cache": "^10.0|^11.0",
+        "illuminate/config": "^10.0|^11.0",
+        "illuminate/console": "^10.0|^11.0",
+        "illuminate/container": "^10.0|^11.0",
+        "illuminate/contracts": "^10.0|^11.0",
+        "illuminate/events": "^10.0|^11.0",
+        "illuminate/filesystem": "^10.0|^11.0",
+        "illuminate/notifications": "^10.0|^11.0",
+        "illuminate/support": "^10.0|^11.0",
+        "laravel/slack-notification-channel": "^2.4|^3.2",
         "spatie/ssl-certificate": "^1.22|^2.1.2",
         "spatie/url": "^2.0.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.4",
-        "illuminate/testing": "^8.73|^9.0|^10.0",
-        "orchestra/testbench": "^6.23|^7.0|^8.0",
-        "phpunit/phpunit": "^9.5"
+        "illuminate/testing": "^10.0|^11.0",
+        "orchestra/testbench": "^8.0|^9.0",
+        "phpunit/phpunit": "^9.5|^10.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <testsuites>
     <testsuite name="Spatie Test Suite">
       <directory>tests</directory>

--- a/src/Helpers/Period.php
+++ b/src/Helpers/Period.php
@@ -26,11 +26,11 @@ class Period
     {
         $interval = $this->startDateTime->diff($this->endDateTime);
 
-        if (! $this->startDateTime->diffInHours($this->endDateTime)) {
+        if ($this->startDateTime->diffInHours($this->endDateTime) < 1) {
             return $interval->format('%im');
         }
 
-        if (! $this->startDateTime->diffInDays($this->endDateTime)) {
+        if ($this->startDateTime->diffInDays($this->endDateTime) < 1) {
             return $interval->format('%hh %im');
         }
 

--- a/src/Models/Traits/SupportsCertificateCheck.php
+++ b/src/Models/Traits/SupportsCertificateCheck.php
@@ -52,7 +52,7 @@ trait SupportsCertificateCheck
         if ($this->certificate_status === CertificateStatus::VALID) {
             event(new CertificateCheckSucceeded($this, $certificate));
 
-            if ($certificate->expirationDate()->diffInDays() <= config('uptime-monitor.certificate_check.fire_expiring_soon_event_if_certificate_expires_within_days')) {
+            if ($certificate->expirationDate()->diffInDays(absolute: true) <= config('uptime-monitor.certificate_check.fire_expiring_soon_event_if_certificate_expires_within_days')) {
                 event(new CertificateExpiresSoon($monitor, $certificate));
             }
 

--- a/src/Models/Traits/SupportsUptimeCheck.php
+++ b/src/Models/Traits/SupportsUptimeCheck.php
@@ -47,7 +47,7 @@ trait SupportsUptimeCheck
             return true;
         }
 
-        return $this->uptime_last_check_date->diffInMinutes() >= $this->uptime_check_interval_in_minutes;
+        return (int)$this->uptime_last_check_date->diffInMinutes(absolute: true) >= $this->uptime_check_interval_in_minutes;
     }
 
     public function uptimeRequestSucceeded(ResponseInterface $response): void

--- a/tests/Integration/Helpers/PeriodTest.php
+++ b/tests/Integration/Helpers/PeriodTest.php
@@ -29,7 +29,7 @@ class PeriodTest extends TestCase
         $this->assertEquals($formattedString, $period->duration());
     }
 
-    public function periodDataProvider(): array
+    public static function periodDataProvider(): array
     {
         return [
             [10, '10m'],
@@ -54,7 +54,7 @@ class PeriodTest extends TestCase
         $this->assertEquals($text, $period->toText());
     }
 
-    public function textDataProvider(): array
+    public static function textDataProvider(): array
     {
         Carbon::setTestNow(Carbon::create(2016, 1, 1, 00, 00, 00));
 

--- a/tests/Integration/Models/Traits/SupportsCertificateCheckTest.php
+++ b/tests/Integration/Models/Traits/SupportsCertificateCheckTest.php
@@ -30,7 +30,7 @@ class SupportsCertificateCheckTest extends TestCase
         $this->monitor = Monitor::factory()->create([
             'certificate_check_enabled' => true,
             'certificate_status' => CertificateStatus::NOT_YET_CHECKED,
-            'url' => self::DOMAIN
+            'url' => self::DOMAIN,
         ]);
 
         $this->certificate = Downloader::downloadCertificateFromUrl(self::DOMAIN);

--- a/tests/Integration/Models/Traits/SupportsCertificateCheckTest.php
+++ b/tests/Integration/Models/Traits/SupportsCertificateCheckTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Spatie\UptimeMonitor\Test\Integration\Models\Traits;
+
+use Carbon\Carbon;
+use Exception;
+use Illuminate\Support\Facades\Event;
+use Spatie\SslCertificate\Downloader;
+use Spatie\SslCertificate\SslCertificate;
+use Spatie\UptimeMonitor\Events\CertificateCheckFailed;
+use Spatie\UptimeMonitor\Events\CertificateCheckSucceeded;
+use Spatie\UptimeMonitor\Events\CertificateExpiresSoon;
+use Spatie\UptimeMonitor\Models\Enums\CertificateStatus;
+use Spatie\UptimeMonitor\Models\Monitor;
+use Spatie\UptimeMonitor\Test\TestCase;
+
+class SupportsCertificateCheckTest extends TestCase
+{
+    protected Monitor $monitor;
+    protected int $daysBeforeExpiration;
+    protected SslCertificate $certificate;
+    protected const DOMAIN = 'https://google.com';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Event::fake();
+
+        $this->monitor = Monitor::factory()->create([
+            'certificate_check_enabled' => true,
+            'certificate_status' => CertificateStatus::NOT_YET_CHECKED,
+            'url' => self::DOMAIN
+        ]);
+
+        $this->certificate = Downloader::downloadCertificateFromUrl(self::DOMAIN);
+        $this->daysBeforeExpiration = config(
+            'uptime-monitor.certificate_check.fire_expiring_soon_event_if_certificate_expires_within_days'
+        );
+    }
+
+    /** @test */
+    public function it_can_set_valid_certificate_not_within_expiration_range()
+    {
+        // Collect
+        Carbon::setTestNow($this->certificate->expirationDate()->subDays($this->daysBeforeExpiration + 1));
+
+        // Act
+        $this->monitor->setCertificate($this->certificate);
+
+        // Assert
+        $this->monitor->fresh();
+        $this->assertSame(CertificateStatus::VALID, $this->monitor->certificate_status);
+        $this->assertSame($this->certificate->getIssuer(), $this->monitor->certificate_issuer);
+        $this->assertTrue($this->monitor->certificate_expiration_date->isSameDay($this->certificate->expirationDate()));
+        Event::assertDispatched(CertificateCheckSucceeded::class);
+        Event::assertNotDispatched(CertificateCheckFailed::class);
+        Event::assertNotDispatched(CertificateExpiresSoon::class);
+    }
+
+    /** @test */
+    public function it_can_set_valid_certificate_within_expiration_range()
+    {
+        // Collect
+        Carbon::setTestNow($this->certificate->expirationDate()->subDays($this->daysBeforeExpiration - 1));
+
+        // Act
+        $this->monitor->setCertificate($this->certificate);
+
+        // Assert
+        $this->monitor->fresh();
+        $this->assertSame(CertificateStatus::VALID, $this->monitor->certificate_status);
+        $this->assertSame($this->certificate->getIssuer(), $this->monitor->certificate_issuer);
+        $this->assertTrue($this->monitor->certificate_expiration_date->isSameDay($this->certificate->expirationDate()));
+        Event::assertDispatched(CertificateCheckSucceeded::class);
+        Event::assertDispatched(CertificateExpiresSoon::class);
+        Event::assertNotDispatched(CertificateCheckFailed::class);
+    }
+
+    /** @test */
+    public function it_can_set_invalid_certificate()
+    {
+        // Collect
+        Carbon::setTestNow($this->certificate->expirationDate()->addDay());
+
+        // Act
+        $this->monitor->setCertificate($this->certificate);
+
+        // Assert
+        $this->monitor->fresh();
+        $this->assertSame(CertificateStatus::INVALID, $this->monitor->certificate_status);
+        $this->assertSame('The certificate has expired', $this->monitor->certificate_check_failure_reason);
+        $this->assertSame($this->certificate->getIssuer(), $this->monitor->certificate_issuer);
+        $this->assertTrue($this->monitor->certificate_expiration_date->isSameDay($this->certificate->expirationDate()));
+        Event::assertDispatched(CertificateCheckFailed::class);
+        Event::assertNotDispatched(CertificateCheckSucceeded::class);
+        Event::assertNotDispatched(CertificateExpiresSoon::class);
+    }
+
+    /** @test */
+    public function it_can_set_certificate_exception()
+    {
+        // Collect
+        $exception = new Exception('Certificate check failed');
+
+        // Act
+        $this->monitor->setCertificateException($exception);
+
+        // Assert
+        $this->monitor->fresh();
+        $this->assertSame(CertificateStatus::INVALID, $this->monitor->certificate_status);
+        $this->assertSame('Certificate check failed', $this->monitor->certificate_check_failure_reason);
+        $this->assertSame('', $this->monitor->certificate_issuer);
+        $this->assertNull($this->monitor->certificate_expiration_date);
+        Event::assertDispatched(CertificateCheckFailed::class);
+    }
+}

--- a/tests/Integration/Models/Traits/SupportsUptimeCheckTest.php
+++ b/tests/Integration/Models/Traits/SupportsUptimeCheckTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\UptimeMonitor\Test\Integration\Models\Traits;
 
 use Carbon\Carbon;
+use PHPUnit\Framework\Constraint\IsEqualWithDelta;
 use Spatie\UptimeMonitor\Models\Enums\UptimeStatus;
 use Spatie\UptimeMonitor\Models\Monitor;
 use Spatie\UptimeMonitor\Test\TestCase;
@@ -101,6 +102,14 @@ class SupportsUptimeCheckTest extends TestCase
     {
         $this->monitor = $this->monitor->fresh();
 
-        return $this->monitor->$attribute->diffInMinutes() === 0;
+        $constraint = new IsEqualWithDelta(
+            value: 0,
+            delta: 1,
+        );
+
+        return $constraint->evaluate(
+            other: $this->monitor->$attribute->diffInMinutes(),
+            returnResult: true
+        );
     }
 }

--- a/tests/Integration/Notifications/EventHandlerTest.php
+++ b/tests/Integration/Notifications/EventHandlerTest.php
@@ -75,7 +75,7 @@ class EventHandlerTest extends TestCase
         }
     }
 
-    public function eventClassDataProvider(): array
+    public static function eventClassDataProvider(): array
     {
         return [
             [UptimeCheckSucceededEvent::class, UptimeCheckSucceeded::class, ['uptime_status' => UptimeStatus::UP], true],
@@ -127,7 +127,7 @@ class EventHandlerTest extends TestCase
         );
     }
 
-    public function channelDataProvider(): array
+    public static function channelDataProvider(): array
     {
         return [
             [['mail']],

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -57,6 +57,9 @@ abstract class TestCase extends Orchestra
             'database' => ':memory:',
         ]);
 
+        $app['config']->set('uptime-monitor.notifications.slack.webhook_url', 'https://hooks.slack.com/fake');
+        $app['config']->set('uptime-monitor.certificate_check.fire_expiring_soon_event_if_certificate_expires_within_days', 15);
+
         $this->setUpDatabase();
     }
 


### PR DESCRIPTION
- updated composer dependencies to support Laravel 11
- removed support for unmaintained Laravel and PHP versions
- add support for carbon 3 [diffIn methods now returning floats](https://carbon.nesbot.com/docs/#api-carbon-3-diff-in)

Shoutout @mbabker for the discovery work here: https://github.com/spatie/laravel-uptime-monitor/pull/353#issuecomment-2120619815

**Note:** This will need a major version bump to account for the removal of support for unmaintained Laravel and php versions. 