### PR TITLE
Make other notification getMessageText() public aswell

### DIFF
--- a/src/Notifications/Notifications/CertificateExpiresSoon.php
+++ b/src/Notifications/Notifications/CertificateExpiresSoon.php
@@ -54,7 +54,7 @@ class CertificateExpiresSoon extends BaseNotification
         return $this;
     }
 
-    protected function getMessageText(): string
+    public function getMessageText(): string
     {
         return "SSL certificate for {$this->getMonitor()->url} expires soon";
     }

--- a/src/Notifications/Notifications/UptimeCheckFailed.php
+++ b/src/Notifications/Notifications/UptimeCheckFailed.php
@@ -74,7 +74,7 @@ class UptimeCheckFailed extends BaseNotification
         return $this;
     }
 
-    protected function getMessageText(): string
+    public function getMessageText(): string
     {
         return "{$this->getMonitor()->url} seems down";
     }


### PR DESCRIPTION
All notification classes have the ``getMessageText()`` method as a public method, but in these two classes, it is protected. I noticed this when I tried to call the getMessageText function on the Notification class.