### PR TITLE
Allow custom success status codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ return [
          * When reaching out to the sites these headers will be added.
          */
         'additional_headers' => [],
+        
+        /*
+         * Allow status codes other than 200 to be considered as successful uptime checks.
+         */
+        'additional_status_codes' => [],
     ],
 
     'certificate_check' => [

--- a/config/uptime-monitor.php
+++ b/config/uptime-monitor.php
@@ -113,6 +113,11 @@ return [
          * When reaching out to the sites these headers will be added.
          */
         'additional_headers' => [],
+
+        /*
+         * All status codes in this array will be interpreted as successful requests.
+         */
+        'additional_status_codes' => [],
     ],
 
     'certificate_check' => [

--- a/src/MonitorCollection.php
+++ b/src/MonitorCollection.php
@@ -55,6 +55,17 @@ class MonitorCollection extends Collection
                     'headers' => $this->promiseHeaders($monitor),
                     'body' => $monitor->uptime_check_payload,
                 ])
+            )->then(
+                function (ResponseInterface $response) {
+                    return $response;
+                },
+                function (TransferException $exception) {
+                    if (in_array($exception->getCode(), config('uptime-monitor.uptime_check.additional_status_codes', []))) {
+                        return $exception->getResponse();
+                    }
+
+                    throw $exception;
+                }
             );
 
             yield $promise;


### PR DESCRIPTION
Sometimes it might be useful to allow custom http status codes such as `401` which might be a password protected website that is still online.

This PR allows us to configure additional allowed http status codes:

```php
'uptime_check' => [
        // ...
        'additional_status_codes' => [401],
]
```

Please let me know if this is useful for this package and I'll try to figure out how to add tests for this behaviour.