### PR TITLE
Update SupportsUptimeCheck.php to handle clone error on non object value

### DIFF
--- a/src/Models/Traits/SupportsUptimeCheck.php
+++ b/src/Models/Traits/SupportsUptimeCheck.php
@@ -76,7 +76,9 @@ trait SupportsUptimeCheck
         $this->uptime_check_failure_reason = '';
 
         $wasFailing = ! is_null($this->uptime_check_failed_event_fired_on_date);
-        $lastStatusChangeDate = $this->uptime_status_last_change_date ? clone $this->uptime_status_last_change_date : null;
+        $lastStatusChangeDate = is_object($this->uptime_status_last_change_date)
+            ? clone $this->uptime_status_last_change_date
+            : null;
 
         $this->uptime_check_times_failed_in_a_row = 0;
         $this->uptime_last_check_date = Carbon::now();


### PR DESCRIPTION
__clone method called on non-object

```php
70         $this->uptimeCheckFailed($reason);
71     }
72 
73     public function uptimeCheckSucceeded(): void
74     {
75         $this->uptime_status = UptimeStatus::UP;
76         $this->uptime_check_failure_reason = '';
77 
78         $wasFailing = ! is_null($this->uptime_check_failed_event_fired_on_date);
79         $lastStatusChangeDate = $this->uptime_status_last_change_date ? clone $this->uptime_status_last_change_date :null;
80 
81         $this->uptime_check_times_failed_in_a_row = 0;
82         $this->uptime_last_check_date = Carbon::now();
83         $this->uptime_check_failed_event_fired_on_date = null;
84         $this->save();
85 
86         if ($wasFailing) {
87             $downtimePeriod = new Period($lastStatusChangeDate, $this->uptime_last_check_date);
88 
89             event(new UptimeCheckRecovered($this, $downtimePeriod));
```

![image](https://github.com/user-attachments/assets/f654c8e1-a6cb-4997-be4c-9e611d8fed16)
