### PR TITLE
Exception -> Throwable

### DIFF
--- a/src/Helpers/ConsoleOutput.php
+++ b/src/Helpers/ConsoleOutput.php
@@ -6,7 +6,7 @@ use Illuminate\Console\Command;
 
 class ConsoleOutput
 {
-    public static Command $runningCommand;
+    public static ?Command $runningCommand = null;
 
     public function setOutput(Command $runningCommand)
     {

--- a/src/Models/Traits/SupportsCertificateCheck.php
+++ b/src/Models/Traits/SupportsCertificateCheck.php
@@ -2,13 +2,13 @@
 
 namespace Spatie\UptimeMonitor\Models\Traits;
 
-use Exception;
 use Spatie\SslCertificate\SslCertificate;
 use Spatie\UptimeMonitor\Events\CertificateCheckFailed;
 use Spatie\UptimeMonitor\Events\CertificateCheckSucceeded;
 use Spatie\UptimeMonitor\Events\CertificateExpiresSoon;
 use Spatie\UptimeMonitor\Models\Enums\CertificateStatus;
 use Spatie\UptimeMonitor\Models\Monitor;
+use Throwable;
 
 trait SupportsCertificateCheck
 {
@@ -18,7 +18,7 @@ trait SupportsCertificateCheck
             $certificate = SslCertificate::createForHostName($this->url->getHost());
 
             $this->setCertificate($certificate);
-        } catch (Exception $exception) {
+        } catch (Throwable $exception) {
             $this->setCertificateException($exception);
         }
     }
@@ -36,7 +36,7 @@ trait SupportsCertificateCheck
         $this->fireEventsForUpdatedMonitorWithCertificate($this, $certificate);
     }
 
-    public function setCertificateException(Exception $exception): void
+    public function setCertificateException(\Throwable $exception): void
     {
         $this->certificate_status = CertificateStatus::INVALID;
         $this->certificate_expiration_date = null;

--- a/src/Models/Traits/SupportsCertificateCheck.php
+++ b/src/Models/Traits/SupportsCertificateCheck.php
@@ -36,7 +36,7 @@ trait SupportsCertificateCheck
         $this->fireEventsForUpdatedMonitorWithCertificate($this, $certificate);
     }
 
-    public function setCertificateException(\Throwable $exception): void
+    public function setCertificateException(Throwable $exception): void
     {
         $this->certificate_status = CertificateStatus::INVALID;
         $this->certificate_expiration_date = null;


### PR DESCRIPTION
In PHP 8+, some failures (like DNS resolution and SSL verification errors) can throw Error exceptions, which don't extend Exception, so they weren't being caught and sites weren't being flagged as down.

Example exceptions: 

```
stream_socket_client(): SSL operation failed with code 1. OpenSSL Error messages:
error:0A000086:SSL routines::certificate verify failed
```

```
stream_socket_client(): php_network_getaddresses: getaddrinfo for www.domain.org failed: Try again
```